### PR TITLE
Ensure that pattern searched files with glob are explicitly sorted

### DIFF
--- a/analysis/postprocess.ipynb
+++ b/analysis/postprocess.ipynb
@@ -23,11 +23,11 @@
     "rules_reader = utils.SessionData()\n",
     "video_reader = utils.Video()\n",
     "\n",
-    "harp_datafolder = r'../temp_data_remote/2024-05-15T17-53-25/Expander/'\n",
-    "settings_datafolder = r'../temp_data_remote/2024-05-15T17-53-25/SessionSettings/'\n",
-    "rules_datafolder = r'../temp_data_remote/2024-05-15T17-53-25/RuleSettings/'\n",
-    "video_datafolder = r'../temp_data_remote/2024-05-15T17-53-25/VideoData/'\n",
-    "output_event_folder = r'../temp_data_remote/2024-05-15T17-53-25/EventResults/'"
+    "harp_datafolder = r'D:/temp_data/ErskineTransfer/Expander/'\n",
+    "settings_datafolder = r'D:/temp_data/ErskineTransfer/SessionSettings/'\n",
+    "rules_datafolder = r'D:/temp_data/ErskineTransfer/RuleSettings/'\n",
+    "video_datafolder = r'D:/temp_data/ErskineTransfer/VideoData/'\n",
+    "output_event_folder = r'D:/temp_data/ErskineTransfer/EventResults/'"
    ]
   },
   {

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -49,21 +49,21 @@ class Video(Csv):
 def load_json(reader: SessionData, root: Path) -> pd.DataFrame:
     root = Path(root)
     pattern = f"{root.joinpath(root.name)}_*.jsonl"
-    data = [reader.read(Path(file)) for file in glob(pattern)]
+    data = [reader.read(Path(file)) for file in sorted(glob(pattern))]
     return pd.concat(data)
 
 
 def load(reader: Reader, root: Path) -> pd.DataFrame:
     root = Path(root)
     pattern = f"{root.joinpath(root.name)}_{reader.register.address}_*.bin"
-    data = [reader.read(file) for file in glob(pattern)]
+    data = [reader.read(file) for file in sorted(glob(pattern))]
     return pd.concat(data)
 
 
 def load_video(reader: Video, root: Path) -> pd.DataFrame:
     root = Path(root)
     pattern = f"{root.joinpath(root.name)}_*.csv"
-    data = [reader.read(Path(file)) for file in glob(pattern)]
+    data = [reader.read(Path(file)) for file in sorted(glob(pattern))]
     return pd.concat(data)
 
 def concat_digi_events(series_low: pd.DataFrame, series_high: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
In some cases (filesystems for remote drives?) using `glob` to search for files returns unordered (by date) file names. This can cause an error in the postprocessing script for example where frame times / counts are read out of order with each other. Fix in this PR is to explicitly order the output of `glob` in the utils.