### PR TITLE
Add robocopy toggle to schema and workflow

### DIFF
--- a/src/DelphiMain.bonsai
+++ b/src/DelphiMain.bonsai
@@ -1774,6 +1774,27 @@
             <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p5:Unit">
               <rx:Name>StartRobocopy</rx:Name>
             </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Name>RobocopyEnabled</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>SessionSettings</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Metadata.RobocopyEnabled</Selector>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
             <Expression xsi:type="rx:SelectMany">
               <Name>Robocopy</Name>
               <Workflow>
@@ -1880,6 +1901,7 @@
             <Edge From="51" To="52" Label="Source1" />
             <Edge From="52" To="53" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
+            <Edge From="55" To="56" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/DelphiMain.bonsai.layout
+++ b/src/DelphiMain.bonsai.layout
@@ -28,12 +28,12 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>3</X>
-        <Y>3</Y>
+        <X>4</X>
+        <Y>4</Y>
       </Location>
       <Size>
-        <Width>2146</Width>
-        <Height>1263</Height>
+        <Width>1019</Width>
+        <Height>699</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -366,12 +366,12 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>3</X>
-        <Y>3</Y>
+        <X>4</X>
+        <Y>4</Y>
       </Location>
       <Size>
-        <Width>2146</Width>
-        <Height>1263</Height>
+        <Width>1019</Width>
+        <Height>699</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -390,12 +390,12 @@
         <EditorDialogSettings>
           <Visible>true</Visible>
           <Location>
-            <X>3</X>
-            <Y>3</Y>
+            <X>4</X>
+            <Y>4</Y>
           </Location>
           <Size>
-            <Width>2146</Width>
-            <Height>1263</Height>
+            <Width>1019</Width>
+            <Height>699</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -1092,12 +1092,12 @@
         <EditorDialogSettings>
           <Visible>true</Visible>
           <Location>
-            <X>3</X>
-            <Y>3</Y>
+            <X>4</X>
+            <Y>4</Y>
           </Location>
           <Size>
-            <Width>2146</Width>
-            <Height>1263</Height>
+            <Width>1019</Width>
+            <Height>699</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -1236,12 +1236,12 @@
             <EditorDialogSettings>
               <Visible>true</Visible>
               <Location>
-                <X>3</X>
-                <Y>3</Y>
+                <X>4</X>
+                <Y>4</Y>
               </Location>
               <Size>
-                <Width>2146</Width>
-                <Height>1263</Height>
+                <Width>1019</Width>
+                <Height>699</Height>
               </Size>
               <WindowState>Normal</WindowState>
             </EditorDialogSettings>
@@ -1420,12 +1420,12 @@
         <EditorDialogSettings>
           <Visible>true</Visible>
           <Location>
-            <X>3</X>
-            <Y>3</Y>
+            <X>4</X>
+            <Y>4</Y>
           </Location>
           <Size>
-            <Width>2146</Width>
-            <Height>1263</Height>
+            <Width>1019</Width>
+            <Height>699</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -1528,12 +1528,12 @@
             <EditorDialogSettings>
               <Visible>true</Visible>
               <Location>
-                <X>3</X>
-                <Y>3</Y>
+                <X>4</X>
+                <Y>4</Y>
               </Location>
               <Size>
-                <Width>2146</Width>
-                <Height>1263</Height>
+                <Width>1019</Width>
+                <Height>699</Height>
               </Size>
               <WindowState>Normal</WindowState>
             </EditorDialogSettings>
@@ -2038,12 +2038,12 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>3</X>
-        <Y>3</Y>
+        <X>4</X>
+        <Y>4</Y>
       </Location>
       <Size>
-        <Width>2146</Width>
-        <Height>1263</Height>
+        <Width>1019</Width>
+        <Height>699</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -2708,6 +2708,30 @@
         </Size>
         <WindowState>Normal</WindowState>
       </DialogSettings>
+      <DialogSettings xsi:type="WorkflowEditorSettings">
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+        <EditorDialogSettings>
+          <Visible>false</Visible>
+          <Location>
+            <X>428</X>
+            <Y>272</Y>
+          </Location>
+          <Size>
+            <Width>314</Width>
+            <Height>238</Height>
+          </Size>
+          <WindowState>Normal</WindowState>
+        </EditorDialogSettings>
+      </DialogSettings>
       <DialogSettings>
         <Visible>false</Visible>
         <Location>
@@ -2863,12 +2887,12 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>3</X>
-        <Y>3</Y>
+        <X>4</X>
+        <Y>4</Y>
       </Location>
       <Size>
-        <Width>2146</Width>
-        <Height>1263</Height>
+        <Width>1019</Width>
+        <Height>699</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>

--- a/src/Extensions/DataSchema.Generated.cs
+++ b/src/Extensions/DataSchema.Generated.cs
@@ -603,6 +603,8 @@ namespace DataSchema
     
         private double _maximumPokeTime = 10D;
     
+        private bool _robocopyEnabled = true;
+    
         private double _robocopyTimeInterval = 3600D;
     
         private double _maxVideoLength = 120D;
@@ -635,6 +637,7 @@ namespace DataSchema
             _chargeTime = other._chargeTime;
             _minimumPokeTime = other._minimumPokeTime;
             _maximumPokeTime = other._maximumPokeTime;
+            _robocopyEnabled = other._robocopyEnabled;
             _robocopyTimeInterval = other._robocopyTimeInterval;
             _maxVideoLength = other._maxVideoLength;
             _minOdorDelivery = other._minOdorDelivery;
@@ -743,6 +746,23 @@ namespace DataSchema
             set
             {
                 _maximumPokeTime = value;
+            }
+        }
+    
+        /// <summary>
+        /// Whether to enable robocopy remote transfer
+        /// </summary>
+        [YamlDotNet.Serialization.YamlMemberAttribute(Alias="robocopyEnabled")]
+        [System.ComponentModel.DescriptionAttribute("Whether to enable robocopy remote transfer")]
+        public bool RobocopyEnabled
+        {
+            get
+            {
+                return _robocopyEnabled;
+            }
+            set
+            {
+                _robocopyEnabled = value;
             }
         }
     
@@ -934,6 +954,7 @@ namespace DataSchema
             stringBuilder.Append("chargeTime = " + _chargeTime + ", ");
             stringBuilder.Append("minimumPokeTime = " + _minimumPokeTime + ", ");
             stringBuilder.Append("maximumPokeTime = " + _maximumPokeTime + ", ");
+            stringBuilder.Append("robocopyEnabled = " + _robocopyEnabled + ", ");
             stringBuilder.Append("robocopyTimeInterval = " + _robocopyTimeInterval + ", ");
             stringBuilder.Append("maxVideoLength = " + _maxVideoLength + ", ");
             stringBuilder.Append("minOdorDelivery = " + _minOdorDelivery + ", ");

--- a/src/data-schema.json
+++ b/src/data-schema.json
@@ -110,6 +110,11 @@
                     "default": "10",
                     "type": "number"
                 },
+                "robocopyEnabled": {
+                    "description": "Whether to enable robocopy remote transfer",
+                    "default": "True",
+                    "type": "boolean"
+                },
                 "robocopyTimeInterval": {
                     "description": "Interval between robocopy initiations in seconds",
                     "default": "3600",


### PR DESCRIPTION
This PR introduces a boolean schema parameter "robocopyEnabled" which allows the user to define whether the robocopy subprocess is called during data logging. Useful for testing and debugging purposes where remote data storage is unavailable or not configured.