### PR TITLE
Subject session schema info

### DIFF
--- a/src/DelphiMain.bonsai
+++ b/src/DelphiMain.bonsai
@@ -1345,6 +1345,25 @@
             <Expression xsi:type="MemberSelector">
               <Selector>LoggingRootPath</Selector>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>HardwareSchema</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>SubjectId</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>HardwareSchema</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>SessionTime</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>{0}\{1}\{2}</Format>
+              <Selector>Item1,Item2,Item3</Selector>
+            </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
                 <Property Name="Path" />
@@ -1972,10 +1991,11 @@ groupMasks:
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="1" To="6" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="4" To="6" Label="Source1" />
-            <Edge From="5" To="6" Label="Source2" />
+            <Edge From="3" To="6" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source3" />
             <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
@@ -1983,13 +2003,18 @@ groupMasks:
             <Edge From="11" To="12" Label="Source2" />
             <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="16" To="18" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
             <Edge From="18" To="19" Label="Source1" />
             <Edge From="19" To="20" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
+            <Edge From="25" To="26" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/DelphiMain.bonsai
+++ b/src/DelphiMain.bonsai
@@ -35,7 +35,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="io:ReadAllText">
-                <io:Path>schemas\hardware-schema.yml</io:Path>
+                <io:Path>C:\Users\svc_aind_chronic\Documents\code\Delphi\src\schemas\hardware-schema_77777777_2026-03-17T21-45-55.yml</io:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="p1:DeserializeFromYaml">
@@ -54,7 +54,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="p2:RuleSelector">
-                <p2:Path>schemas\rule-3.yml</p2:Path>
+                <p2:Path>C:\Users\svc_aind_chronic\Documents\code\Delphi\src\schemas\rule-3.yml</p2:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -62,7 +62,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="p2:RuleSelector">
-                <p2:Path>schemas\rule-5.yml</p2:Path>
+                <p2:Path>C:\Users\svc_aind_chronic\Documents\code\Delphi\src\schemas\rule-3.yml</p2:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -221,7 +221,7 @@
                 <harp:VisualIndicators>On</harp:VisualIndicators>
                 <harp:Heartbeat>Enabled</harp:Heartbeat>
                 <harp:IgnoreErrors>false</harp:IgnoreErrors>
-                <harp:PortName>COM3</harp:PortName>
+                <harp:PortName>COM7</harp:PortName>
               </Combinator>
             </Expression>
             <Expression xsi:type="rx:PublishSubject">
@@ -437,7 +437,7 @@
                   <Expression xsi:type="p4:CreateMessage">
                     <harp:MessageType>Write</harp:MessageType>
                     <harp:Payload xsi:type="p4:CreateFinalValveEnergizedTimeUSPayload">
-                      <p4:FinalValveEnergizedTimeUS>110000</p4:FinalValveEnergizedTimeUS>
+                      <p4:FinalValveEnergizedTimeUS>0</p4:FinalValveEnergizedTimeUS>
                     </harp:Payload>
                   </Expression>
                   <Expression xsi:type="MulticastSubject">
@@ -1221,119 +1221,121 @@
           </Edges>
         </Workflow>
       </Expression>
-      <Expression xsi:type="GroupWorkflow">
-        <Name>CameraController</Name>
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\CameraController.bonsai" />
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DelphiEvents</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="harp:FilterMessageType">
-                <harp:FilterType>Include</harp:FilterType>
-                <harp:MessageType>Event</harp:MessageType>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="p4:Parse">
-              <harp:Register xsi:type="p4:TimestampedCamPinState" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>CameraStarted</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:SkipUntil" />
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Seconds</Selector>
-            </Expression>
-            <Expression xsi:type="rx:PublishSubject">
-              <Name>FrameEvent</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>HardwareSchema</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>CameraSettings.SerialNumber</Selector>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="SerialNumber" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>HardwareSchema</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>CameraSettings.Exposure</Selector>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="ExposureTime" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="aeon:SpinnakerCapture">
-                <spk:Index xsi:nil="true" />
-                <spk:SerialNumber>23373886</spk:SerialNumber>
-                <spk:ColorProcessing>Default</spk:ColorProcessing>
-                <aeon:ExposureTime>5000</aeon:ExposureTime>
-                <aeon:Gain>0</aeon:Gain>
-                <aeon:Binning>1</aeon:Binning>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="rx:PublishSubject">
-              <Name>CameraFrame</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>CameraFrame</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:IsEmpty" />
-            </Expression>
-            <Expression xsi:type="BitwiseNot" />
-            <Expression xsi:type="rx:PublishSubject">
-              <Name>CameraStarted</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>CameraFrame</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>FrameEvent</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Zip" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="harp:CreateTimestamped" />
-            </Expression>
-            <Expression xsi:type="rx:PublishSubject">
-              <Name>VideoFeed</Name>
-            </Expression>
-          </Nodes>
-          <Edges>
-            <Edge From="1" To="2" Label="Source1" />
-            <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="5" Label="Source1" />
-            <Edge From="4" To="5" Label="Source2" />
-            <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="14" Label="Source1" />
-            <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="14" Label="Source2" />
-            <Edge From="14" To="15" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="19" Label="Source1" />
-            <Edge From="20" To="22" Label="Source1" />
-            <Edge From="21" To="22" Label="Source2" />
-            <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
-          </Edges>
-        </Workflow>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="GroupWorkflow">
+          <Name>CameraController</Name>
+          <Workflow>
+            <Nodes>
+              <Expression xsi:type="IncludeWorkflow" Path="Extensions\CameraController.bonsai" />
+              <Expression xsi:type="SubscribeSubject">
+                <Name>DelphiEvents</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="harp:FilterMessageType">
+                  <harp:FilterType>Include</harp:FilterType>
+                  <harp:MessageType>Event</harp:MessageType>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="p4:Parse">
+                <harp:Register xsi:type="p4:TimestampedCamPinState" />
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>CameraStarted</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:SkipUntil" />
+              </Expression>
+              <Expression xsi:type="MemberSelector">
+                <Selector>Seconds</Selector>
+              </Expression>
+              <Expression xsi:type="rx:PublishSubject">
+                <Name>FrameEvent</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>HardwareSchema</Name>
+              </Expression>
+              <Expression xsi:type="MemberSelector">
+                <Selector>CameraSettings.SerialNumber</Selector>
+              </Expression>
+              <Expression xsi:type="PropertyMapping">
+                <PropertyMappings>
+                  <Property Name="SerialNumber" />
+                </PropertyMappings>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>HardwareSchema</Name>
+              </Expression>
+              <Expression xsi:type="MemberSelector">
+                <Selector>CameraSettings.Exposure</Selector>
+              </Expression>
+              <Expression xsi:type="PropertyMapping">
+                <PropertyMappings>
+                  <Property Name="ExposureTime" />
+                </PropertyMappings>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="aeon:SpinnakerCapture">
+                  <spk:Index xsi:nil="true" />
+                  <spk:SerialNumber>23373886</spk:SerialNumber>
+                  <spk:ColorProcessing>Default</spk:ColorProcessing>
+                  <aeon:ExposureTime>5000</aeon:ExposureTime>
+                  <aeon:Gain>0</aeon:Gain>
+                  <aeon:Binning>1</aeon:Binning>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="rx:PublishSubject">
+                <Name>CameraFrame</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>CameraFrame</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:IsEmpty" />
+              </Expression>
+              <Expression xsi:type="BitwiseNot" />
+              <Expression xsi:type="rx:PublishSubject">
+                <Name>CameraStarted</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>CameraFrame</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>FrameEvent</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Zip" />
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="harp:CreateTimestamped" />
+              </Expression>
+              <Expression xsi:type="rx:PublishSubject">
+                <Name>VideoFeed</Name>
+              </Expression>
+            </Nodes>
+            <Edges>
+              <Edge From="1" To="2" Label="Source1" />
+              <Edge From="2" To="3" Label="Source1" />
+              <Edge From="3" To="5" Label="Source1" />
+              <Edge From="4" To="5" Label="Source2" />
+              <Edge From="5" To="6" Label="Source1" />
+              <Edge From="6" To="7" Label="Source1" />
+              <Edge From="8" To="9" Label="Source1" />
+              <Edge From="9" To="10" Label="Source1" />
+              <Edge From="10" To="14" Label="Source1" />
+              <Edge From="11" To="12" Label="Source1" />
+              <Edge From="12" To="13" Label="Source1" />
+              <Edge From="13" To="14" Label="Source2" />
+              <Edge From="14" To="15" Label="Source1" />
+              <Edge From="16" To="17" Label="Source1" />
+              <Edge From="17" To="18" Label="Source1" />
+              <Edge From="18" To="19" Label="Source1" />
+              <Edge From="20" To="22" Label="Source1" />
+              <Edge From="21" To="22" Label="Source2" />
+              <Edge From="22" To="23" Label="Source1" />
+              <Edge From="23" To="24" Label="Source1" />
+            </Edges>
+          </Workflow>
+        </Builder>
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>Logging</Name>
@@ -1361,10 +1363,15 @@
               <Combinator xsi:type="rx:Zip" />
             </Expression>
             <Expression xsi:type="Format">
-              <Format>{0}\{1}\{2}</Format>
+              <Format>{0}/{1}/{2}</Format>
               <Selector>Item1,Item2,Item3</Selector>
             </Expression>
-            <Expression xsi:type="rx:PublishSubject">
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
               <Name>SessionPath</Name>
             </Expression>
             <Expression xsi:type="PropertyMapping">
@@ -1373,7 +1380,7 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogController.bonsai">
-              <Path>C:\Users\svc_aind_chronic\Documents\data</Path>
+              <Path>D:/data/77777777/2026-03-17T21-45-55</Path>
               <ChunkSize>1</ChunkSize>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
@@ -1415,103 +1422,109 @@
               <ClosingDuration xsi:nil="true" />
               <LogName>RuleSettings</LogName>
             </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PathPrefix</Name>
+            <Expression xsi:type="Disable">
+              <Builder xsi:type="SubscribeSubject">
+                <Name>PathPrefix</Name>
+              </Builder>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="p6:AppendModalitySuffix">
-                <p6:Modality>BehaviorVideos</p6:Modality>
-              </Combinator>
+            <Expression xsi:type="Disable">
+              <Builder xsi:type="Combinator">
+                <Combinator xsi:type="p6:AppendModalitySuffix">
+                  <p6:Modality>BehaviorVideos</p6:Modality>
+                </Combinator>
+              </Builder>
             </Expression>
-            <Expression xsi:type="rx:Defer">
-              <Name>BehaviorVideos</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Take">
-                      <rx:Count>1</rx:Count>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="rx:AsyncSubject">
-                    <Name>PathPrefix</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>VideoFeed</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>HardwareSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>CameraSettings.FrameRate</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="FrameRate" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>HardwareSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>CameraSettings.FfmpegInput</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="InputArguments" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>HardwareSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>CameraSettings.FfmpegOutput</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="OutputArguments" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>HardwareSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>CameraSettings.CameraName</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="LogName" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogVideo.bonsai">
-                    <Heartbeats />
-                    <ClosingDuration>PT30S</ClosingDuration>
-                    <LogName>PortCamera</LogName>
-                    <FrameRate>100</FrameRate>
-                    <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v h264_qsv -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune film -preset fast -crf 21 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M</OutputArguments>
-                    <InputArguments>-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear</InputArguments>
-                  </Expression>
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="3" To="16" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                  <Edge From="6" To="16" Label="Source2" />
-                  <Edge From="7" To="8" Label="Source1" />
-                  <Edge From="8" To="9" Label="Source1" />
-                  <Edge From="9" To="16" Label="Source3" />
-                  <Edge From="10" To="11" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
-                  <Edge From="12" To="16" Label="Source4" />
-                  <Edge From="13" To="14" Label="Source1" />
-                  <Edge From="14" To="15" Label="Source1" />
-                  <Edge From="15" To="16" Label="Source5" />
-                </Edges>
-              </Workflow>
+            <Expression xsi:type="Disable">
+              <Builder xsi:type="rx:Defer">
+                <Name>BehaviorVideos</Name>
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="Combinator">
+                      <Combinator xsi:type="rx:Take">
+                        <rx:Count>1</rx:Count>
+                      </Combinator>
+                    </Expression>
+                    <Expression xsi:type="rx:AsyncSubject">
+                      <Name>PathPrefix</Name>
+                    </Expression>
+                    <Expression xsi:type="SubscribeSubject">
+                      <Name>VideoFeed</Name>
+                    </Expression>
+                    <Expression xsi:type="SubscribeSubject">
+                      <Name>HardwareSchema</Name>
+                    </Expression>
+                    <Expression xsi:type="MemberSelector">
+                      <Selector>CameraSettings.FrameRate</Selector>
+                    </Expression>
+                    <Expression xsi:type="PropertyMapping">
+                      <PropertyMappings>
+                        <Property Name="FrameRate" />
+                      </PropertyMappings>
+                    </Expression>
+                    <Expression xsi:type="SubscribeSubject">
+                      <Name>HardwareSchema</Name>
+                    </Expression>
+                    <Expression xsi:type="MemberSelector">
+                      <Selector>CameraSettings.FfmpegInput</Selector>
+                    </Expression>
+                    <Expression xsi:type="PropertyMapping">
+                      <PropertyMappings>
+                        <Property Name="InputArguments" />
+                      </PropertyMappings>
+                    </Expression>
+                    <Expression xsi:type="SubscribeSubject">
+                      <Name>HardwareSchema</Name>
+                    </Expression>
+                    <Expression xsi:type="MemberSelector">
+                      <Selector>CameraSettings.FfmpegOutput</Selector>
+                    </Expression>
+                    <Expression xsi:type="PropertyMapping">
+                      <PropertyMappings>
+                        <Property Name="OutputArguments" />
+                      </PropertyMappings>
+                    </Expression>
+                    <Expression xsi:type="SubscribeSubject">
+                      <Name>HardwareSchema</Name>
+                    </Expression>
+                    <Expression xsi:type="MemberSelector">
+                      <Selector>CameraSettings.CameraName</Selector>
+                    </Expression>
+                    <Expression xsi:type="PropertyMapping">
+                      <PropertyMappings>
+                        <Property Name="LogName" />
+                      </PropertyMappings>
+                    </Expression>
+                    <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogVideo.bonsai">
+                      <Heartbeats />
+                      <ClosingDuration>PT30S</ClosingDuration>
+                      <LogName>PortCamera</LogName>
+                      <FrameRate>100</FrameRate>
+                      <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v h264_qsv -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune film -preset fast -crf 21 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M</OutputArguments>
+                      <InputArguments>-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear</InputArguments>
+                    </Expression>
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                    <Edge From="1" To="2" Label="Source1" />
+                    <Edge From="3" To="16" Label="Source1" />
+                    <Edge From="4" To="5" Label="Source1" />
+                    <Edge From="5" To="6" Label="Source1" />
+                    <Edge From="6" To="16" Label="Source2" />
+                    <Edge From="7" To="8" Label="Source1" />
+                    <Edge From="8" To="9" Label="Source1" />
+                    <Edge From="9" To="16" Label="Source3" />
+                    <Edge From="10" To="11" Label="Source1" />
+                    <Edge From="11" To="12" Label="Source1" />
+                    <Edge From="12" To="16" Label="Source4" />
+                    <Edge From="13" To="14" Label="Source1" />
+                    <Edge From="14" To="15" Label="Source1" />
+                    <Edge From="15" To="16" Label="Source5" />
+                  </Edges>
+                </Workflow>
+              </Builder>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>PathPrefix</Name>
@@ -1900,7 +1913,7 @@ groupMasks:
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="io:WriteAllText">
-                            <io:Path>C:\Users\svc_aind_chronic\Documents\data\2026-01-26T21-57-06\behavior\DelphiController\device.yml</io:Path>
+                            <io:Path>D:/data/77777777/2026-03-17T21-45-55\2026-03-17T21-46-15\behavior\DelphiController\device.yml</io:Path>
                             <io:Overwrite>false</io:Overwrite>
                             <io:Append>false</io:Append>
                           </Combinator>
@@ -1942,6 +1955,12 @@ groupMasks:
                     <Name>Source1</Name>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
+                    <Name>HardwareSchema</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>RobocopyScriptPath</Selector>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
                     <Name>SessionPath</Name>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
@@ -1966,25 +1985,25 @@ groupMasks:
                     <Combinator xsi:type="rx:Zip" />
                   </Expression>
                   <Expression xsi:type="Format">
-                    <Format>{0}\{1}\{2}</Format>
+                    <Format>{0}/{1}/{2}</Format>
                     <Selector>Item1,Item2,Item3</Selector>
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Zip" />
                   </Expression>
                   <Expression xsi:type="Format">
-                    <Format>python\robocopy.py {0} {1}</Format>
-                    <Selector>Item1,Item2</Selector>
+                    <Format>{0} {1} {2}</Format>
+                    <Selector>Item1,Item2,Item3</Selector>
                   </Expression>
                   <Expression xsi:type="PropertyMapping">
                     <PropertyMappings>
-                      <Property Name="Arguments" />
+                      <Property Name="Arguments" Selector="it" />
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="io:StartProcess">
                       <io:FileName>..\.venv\Scripts\python.exe</io:FileName>
-                      <io:Arguments>python\robocopy.py C:\Users\svc_aind_chronic\Documents\data \\allen\aind\stage\chronic\Delphi</io:Arguments>
+                      <io:Arguments>C:/Users/svc_aind_chronic/Documents/code/Delphi/src/python/robocopy.py D:/data/22222222/2026-03-17T21-26-19 //allen/aind/stage/chronic/22222222/2026-03-17T21-26-19</io:Arguments>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -1995,20 +2014,22 @@ groupMasks:
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
                 <Edges>
-                  <Edge From="1" To="10" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="8" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="12" Label="Source1" />
+                  <Edge From="3" To="12" Label="Source2" />
                   <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="8" Label="Source2" />
+                  <Edge From="5" To="10" Label="Source1" />
                   <Edge From="6" To="7" Label="Source1" />
-                  <Edge From="7" To="8" Label="Source3" />
+                  <Edge From="7" To="10" Label="Source2" />
                   <Edge From="8" To="9" Label="Source1" />
-                  <Edge From="9" To="10" Label="Source2" />
+                  <Edge From="9" To="10" Label="Source3" />
                   <Edge From="10" To="11" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
+                  <Edge From="11" To="12" Label="Source3" />
                   <Edge From="12" To="13" Label="Source1" />
                   <Edge From="13" To="14" Label="Source1" />
                   <Edge From="14" To="15" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -2024,50 +2045,67 @@ groupMasks:
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="11" To="13" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
-            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="12" To="14" Label="Source1" />
+            <Edge From="13" To="14" Label="Source2" />
             <Edge From="14" To="15" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
-            <Edge From="17" To="19" Label="Source1" />
-            <Edge From="18" To="19" Label="Source2" />
-            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="18" To="20" Label="Source1" />
+            <Edge From="19" To="20" Label="Source2" />
             <Edge From="20" To="21" Label="Source1" />
-            <Edge From="22" To="23" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
             <Edge From="23" To="24" Label="Source1" />
-            <Edge From="25" To="26" Label="Source1" />
+            <Edge From="24" To="25" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
             <Edge From="29" To="30" Label="Source1" />
-            <Edge From="31" To="32" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
+            <Edge From="32" To="33" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Filter" DisplayName="StartCamerasKey" />
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="ExternalizedMapping">
+          <Property Name="Filter" DisplayName="StartCamerasKey" />
+        </Builder>
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="wie:KeyDown">
-          <wie:Filter>LButton A Shift</wie:Filter>
-          <wie:SuppressRepetitions>false</wie:SuppressRepetitions>
-        </Combinator>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="Combinator">
+          <Combinator xsi:type="wie:KeyDown">
+            <wie:Filter>LButton A Shift</wie:Filter>
+            <wie:SuppressRepetitions>false</wie:SuppressRepetitions>
+          </Combinator>
+        </Builder>
       </Expression>
-      <Expression xsi:type="Unit" />
-      <Expression xsi:type="MulticastSubject">
-        <Name>StartCamera</Name>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="Unit" />
       </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Filter" DisplayName="StopCamerasKey" />
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="MulticastSubject">
+          <Name>StartCamera</Name>
+        </Builder>
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="wie:KeyDown">
-          <wie:Filter>LButton A Alt</wie:Filter>
-          <wie:SuppressRepetitions>false</wie:SuppressRepetitions>
-        </Combinator>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="ExternalizedMapping">
+          <Property Name="Filter" DisplayName="StopCamerasKey" />
+        </Builder>
       </Expression>
-      <Expression xsi:type="Unit" />
-      <Expression xsi:type="MulticastSubject">
-        <Name>StopCamera</Name>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="Combinator">
+          <Combinator xsi:type="wie:KeyDown">
+            <wie:Filter>LButton A Alt</wie:Filter>
+            <wie:SuppressRepetitions>false</wie:SuppressRepetitions>
+          </Combinator>
+        </Builder>
+      </Expression>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="Unit" />
+      </Expression>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="MulticastSubject">
+          <Name>StopCamera</Name>
+        </Builder>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>DelphiEvents</Name>
@@ -2114,13 +2152,19 @@ groupMasks:
         <Selector>it</Selector>
       </Expression>
       <Expression xsi:type="VisualizerMapping" />
-      <Expression xsi:type="SubscribeSubject">
-        <Name>VideoFeed</Name>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="SubscribeSubject">
+          <Name>VideoFeed</Name>
+        </Builder>
       </Expression>
-      <Expression xsi:type="MemberSelector">
-        <Selector>Value.Image</Selector>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="MemberSelector">
+          <Selector>Value.Image</Selector>
+        </Builder>
       </Expression>
-      <Expression xsi:type="VisualizerMapping" />
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="VisualizerMapping" />
+      </Expression>
       <Expression xsi:type="viz:TableLayoutPanelBuilder">
         <viz:ColumnCount>4</viz:ColumnCount>
         <viz:RowCount>2</viz:RowCount>
@@ -2131,7 +2175,6 @@ groupMasks:
           <viz:CellSpan ColumnSpan="1" RowSpan="1" />
           <viz:CellSpan ColumnSpan="1" RowSpan="1" />
           <viz:CellSpan ColumnSpan="1" RowSpan="1" />
-          <viz:CellSpan ColumnSpan="4" RowSpan="1" />
         </viz:CellSpans>
       </Expression>
     </Nodes>

--- a/src/DelphiMain.bonsai
+++ b/src/DelphiMain.bonsai
@@ -1364,6 +1364,9 @@
               <Format>{0}\{1}\{2}</Format>
               <Selector>Item1,Item2,Item3</Selector>
             </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>SessionPath</Name>
+            </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
                 <Property Name="Path" />
@@ -1939,16 +1942,32 @@ groupMasks:
                     <Name>Source1</Name>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
-                    <Name>HardwareSchema</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>LoggingRootPath</Selector>
+                    <Name>SessionPath</Name>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
                     <Name>HardwareSchema</Name>
                   </Expression>
                   <Expression xsi:type="MemberSelector">
                     <Selector>RemoteTransferRootPath</Selector>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>HardwareSchema</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>SubjectId</Selector>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>HardwareSchema</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>SessionTime</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Format">
+                    <Format>{0}\{1}\{2}</Format>
+                    <Selector>Item1,Item2,Item3</Selector>
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Zip" />
@@ -1976,15 +1995,20 @@ groupMasks:
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
                 <Edges>
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="5" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source2" />
-                  <Edge From="5" To="6" Label="Source1" />
+                  <Edge From="1" To="10" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="8" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                  <Edge From="5" To="8" Label="Source2" />
                   <Edge From="6" To="7" Label="Source1" />
-                  <Edge From="7" To="8" Label="Source1" />
+                  <Edge From="7" To="8" Label="Source3" />
                   <Edge From="8" To="9" Label="Source1" />
-                  <Edge From="9" To="10" Label="Source1" />
+                  <Edge From="9" To="10" Label="Source2" />
+                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="11" To="12" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -1999,22 +2023,23 @@ groupMasks:
             <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
-            <Edge From="10" To="12" Label="Source1" />
-            <Edge From="11" To="12" Label="Source2" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="11" To="13" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="16" To="18" Label="Source1" />
-            <Edge From="17" To="18" Label="Source2" />
-            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="17" To="19" Label="Source1" />
+            <Edge From="18" To="19" Label="Source2" />
             <Edge From="19" To="20" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="23" To="24" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
-            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="26" To="27" Label="Source1" />
             <Edge From="28" To="29" Label="Source1" />
-            <Edge From="30" To="31" Label="Source1" />
+            <Edge From="29" To="30" Label="Source1" />
+            <Edge From="31" To="32" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Extensions/HardwareSchema.Generated.cs
+++ b/src/Extensions/HardwareSchema.Generated.cs
@@ -376,6 +376,10 @@ namespace HardwareSchema
     public partial class HardwareSchema
     {
     
+        private string _subjectId;
+    
+        private string _sessionTime;
+    
         private string _loggingRootPath;
     
         private string _remoteTransferRootPath;
@@ -392,10 +396,38 @@ namespace HardwareSchema
     
         protected HardwareSchema(HardwareSchema other)
         {
+            _subjectId = other._subjectId;
+            _sessionTime = other._sessionTime;
             _loggingRootPath = other._loggingRootPath;
             _remoteTransferRootPath = other._remoteTransferRootPath;
             _delphiController = other._delphiController;
             _cameraSettings = other._cameraSettings;
+        }
+    
+        [YamlDotNet.Serialization.YamlMemberAttribute(Alias="subject_id")]
+        public string SubjectId
+        {
+            get
+            {
+                return _subjectId;
+            }
+            set
+            {
+                _subjectId = value;
+            }
+        }
+    
+        [YamlDotNet.Serialization.YamlMemberAttribute(Alias="session_time")]
+        public string SessionTime
+        {
+            get
+            {
+                return _sessionTime;
+            }
+            set
+            {
+                _sessionTime = value;
+            }
         }
     
         [YamlDotNet.Serialization.YamlMemberAttribute(Alias="logging_root_path")]
@@ -464,6 +496,8 @@ namespace HardwareSchema
     
         protected virtual bool PrintMembers(System.Text.StringBuilder stringBuilder)
         {
+            stringBuilder.Append("SubjectId = " + _subjectId + ", ");
+            stringBuilder.Append("SessionTime = " + _sessionTime + ", ");
             stringBuilder.Append("LoggingRootPath = " + _loggingRootPath + ", ");
             stringBuilder.Append("RemoteTransferRootPath = " + _remoteTransferRootPath + ", ");
             stringBuilder.Append("DelphiController = " + _delphiController + ", ");

--- a/src/Extensions/HardwareSchema.Generated.cs
+++ b/src/Extensions/HardwareSchema.Generated.cs
@@ -384,6 +384,8 @@ namespace HardwareSchema
     
         private string _remoteTransferRootPath;
     
+        private string _robocopyScriptPath;
+    
         private DelphiController _delphiController;
     
         private CameraSettings _cameraSettings;
@@ -400,6 +402,7 @@ namespace HardwareSchema
             _sessionTime = other._sessionTime;
             _loggingRootPath = other._loggingRootPath;
             _remoteTransferRootPath = other._remoteTransferRootPath;
+            _robocopyScriptPath = other._robocopyScriptPath;
             _delphiController = other._delphiController;
             _cameraSettings = other._cameraSettings;
         }
@@ -456,6 +459,19 @@ namespace HardwareSchema
             }
         }
     
+        [YamlDotNet.Serialization.YamlMemberAttribute(Alias="robocopy_script_path")]
+        public string RobocopyScriptPath
+        {
+            get
+            {
+                return _robocopyScriptPath;
+            }
+            set
+            {
+                _robocopyScriptPath = value;
+            }
+        }
+    
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         [YamlDotNet.Serialization.YamlMemberAttribute(Alias="delphi_controller")]
         public DelphiController DelphiController
@@ -500,6 +516,7 @@ namespace HardwareSchema
             stringBuilder.Append("SessionTime = " + _sessionTime + ", ");
             stringBuilder.Append("LoggingRootPath = " + _loggingRootPath + ", ");
             stringBuilder.Append("RemoteTransferRootPath = " + _remoteTransferRootPath + ", ");
+            stringBuilder.Append("RobocopyScriptPath = " + _robocopyScriptPath + ", ");
             stringBuilder.Append("DelphiController = " + _delphiController + ", ");
             stringBuilder.Append("CameraSettings = " + _cameraSettings);
             return true;

--- a/src/launcher/delphi_experiment.json
+++ b/src/launcher/delphi_experiment.json
@@ -1,0 +1,24 @@
+{
+  "experiments": ["Delphi"],
+  "auto_start": false,
+  "parallel": false,
+  "experiments_config": {
+    "Delphi": {
+      "root": "C:/Users/brandon.pratt/Desktop/code/Delphi",
+      "workflow": "src/DelphiMain.bonsai",
+      "session_count": 2,
+      "session_parameters": [
+        {
+          "HardwareSettings": "src/schemas/hardware-schema.yml",
+          "RuleSettings": "src/schemas/rule-1.yml",
+          "NextRuleSettings": "src/schemas/rule-2.yml"
+        },
+        {
+          "HardwareSettings": "src/schemas/hardware-schema2.yml",
+          "RuleSettings": "src/schemas/rule-3.yml",
+          "NextRuleSettings": "src/schemas/rule-4.yml"
+        }
+      ]
+    }
+  }
+}

--- a/src/launcher/delphi_pirouette_experiment.json
+++ b/src/launcher/delphi_pirouette_experiment.json
@@ -1,0 +1,26 @@
+{
+  "experiments": ["Delphi", "Pirouette"],
+  "auto_start": false,
+  "parallel": false,
+  "experiments_config": {
+    "Delphi": {
+      "root": "C:/Users/brandon.pratt/Desktop/code/Delphi",
+      "workflow": "src/DelphiMain.bonsai",
+      "parameters": {
+        "HardwareSettings": "src/schemas/hardware-schema.yml",
+        "RuleSettings": "src/schemas/rule-3.yml",
+        "NextRuleSettings": "src/schemas/rule-5.yml"
+      }
+    },
+    "Pirouette": {
+      "root": "C:/Users/brandon.pratt/Desktop/code/Aind.Behavior.Pirouette",
+      "workflow": "src/WrappedPirouette.bonsai",
+      "parameters": {
+        "RigPath": "local/AindBehaviorPirouetteRig.json",
+        "SessionPath": "local/AindBehaviorSessionModel.json",
+        "ConnectionString": "@tcp://localhost:5557",
+        "LifealertRoot": "C:/Users/brandon.pratt/Desktop/code/lifealert"
+      }
+    }
+  }
+}

--- a/src/launcher/delphi_pirouette_experiment.json
+++ b/src/launcher/delphi_pirouette_experiment.json
@@ -4,22 +4,22 @@
   "parallel": false,
   "experiments_config": {
     "Delphi": {
-      "root": "C:/Users/brandon.pratt/Desktop/code/Delphi",
+      "root": "C:/Users/svc_aind_chronic/Documents/code/Delphi",
       "workflow": "src/DelphiMain.bonsai",
       "parameters": {
         "HardwareSettings": "src/schemas/hardware-schema.yml",
         "RuleSettings": "src/schemas/rule-3.yml",
-        "NextRuleSettings": "src/schemas/rule-5.yml"
+        "NextRuleSettings": "src/schemas/rule-3.yml"
       }
     },
     "Pirouette": {
-      "root": "C:/Users/brandon.pratt/Desktop/code/Aind.Behavior.Pirouette",
+      "root": "C:/Users/svc_aind_chronic/Documents/code/Aind.Behavior.Pirouette",
       "workflow": "src/WrappedPirouette.bonsai",
       "parameters": {
         "RigPath": "local/AindBehaviorPirouetteRig.json",
         "SessionPath": "local/AindBehaviorSessionModel.json",
         "ConnectionString": "@tcp://localhost:5557",
-        "LifealertRoot": "C:/Users/brandon.pratt/Desktop/code/lifealert"
+        "LifealertRoot": "C:/Users/svc_aind_chronic/Documents/code/lifealert"
       }
     }
   }

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -1023,7 +1023,7 @@ def stop_lifealert():
     print("Stopping lifealert processes...")
     for p in LIFEALERT_PROCS:
         try:
-            p.terminate()
+            p.kill()
         except Exception:
             pass
     LIFEALERT_PROCS.clear()
@@ -1109,7 +1109,7 @@ def cleanup_temp_files_and_processes():
         print("\nStopping lifealert processes...")
         for p in LIFEALERT_PROCS:
             try:
-                p.terminate()
+                p.kill()
             except Exception:
                 pass
         LIFEALERT_PROCS.clear()

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -1,0 +1,1600 @@
+"""
+Experiment Launcher for Information Foraging tasks
+
+What's special in this build
+---------------------------
+• DO NOT pass 'LifealertRoot' to Bonsai: it is filtered out at launch time.
+• Pre-launch SUMMARY excludes LifealertRoot (so it mirrors only what Bonsai receives).
+• All other features retained:
+  - Profiles (--experiment <NAME|FILE>) to skip prompts (except Experimenter & Subject).
+  - Multi-experiment & multi-session.
+  - "All experiments" mode (one session per experiment; ask Experimenter & Subject once).
+  - Per-session parameter overrides (session-only), per-session file copies (Option B).
+  - Pirouette temp files under <root>/src are zeroed if they exist (and deleted on exit).
+  - Lifealert menu after Bonsai launch: start/stop, choose directories from a persisted list.
+
+Run examples
+------------
+Interactive:
+    uv run launcher.py
+
+Using a profile by NAME (resolves ./experiments/<NAME>.json|.yaml|.yml):
+    uv run launcher.py --experiment standard_delphi_pirouette
+
+Using a profile by FILE PATH:
+    uv run launcher.py --experiment C:/path/to/my_profile.json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import subprocess
+from pathlib import Path
+from typing import Dict, Any, List, Tuple, Optional
+from datetime import datetime, timezone
+
+# Optional YAML support (if PyYAML is available)
+try:
+    import yaml  # type: ignore
+except Exception:
+    yaml = None
+
+CONFIG_PATH = Path(__file__).with_name("launcher_config.json")
+EXPERIMENTS_DIR = Path(__file__).with_name("experiments")
+SESSIONS_DIR = Path(__file__).with_name("sessions")
+
+# Track per-session files and temp files to clean up at the end
+TEMP_SESSION_FILES: List[str] = []
+# Track lifealert background processes to terminate on exit
+LIFEALERT_PROCS: List[subprocess.Popen] = []
+# Track launched Bonsai processes
+WORKFLOW_PROCS: List[subprocess.Popen] = []
+
+
+# -------------------------------
+# CLI
+# -------------------------------
+def parse_args():
+    p = argparse.ArgumentParser(description="Bonsai multi-experiment launcher")
+    p.add_argument(
+        "--experiment",
+        "-e",
+        help="Profile by NAME (resolved in ./experiments) or a .json/.yaml/.yml FILE path. NONE by default.",
+        default=None,
+    )
+    return p.parse_args()
+
+
+# -------------------------------
+# I/O & basic helpers
+# -------------------------------
+def load_config() -> Dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        print(f"Configuration file not found: {CONFIG_PATH}")
+        print("Please create 'launcher_config.json' next to this script.")
+        sys.exit(1)
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        print("Invalid configuration: expected a top-level JSON object.")
+        sys.exit(1)
+    if "EXPERIMENTS" not in data or not isinstance(data["EXPERIMENTS"], dict):
+        # Backward compatibility: wrap flat maps
+        if any(
+            isinstance(v, dict) and "workflows" in v
+            for v in data.values()
+            if isinstance(v, dict)
+        ):
+            experiments = {k: v for k, v in data.items() if isinstance(v, dict)}
+            data = {"EXPERIMENTS": experiments}
+        else:
+            print("Missing 'EXPERIMENTS' map in configuration.")
+            sys.exit(1)
+    return data
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, ensure_ascii=False)
+
+
+def norm(p: str) -> str:
+    return os.path.normpath(os.path.expanduser(p))
+
+
+def exists_path(p: str) -> bool:
+    return os.path.exists(norm(p))
+
+
+def prompt(prompt_text: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    val = input(f"{prompt_text}{suffix}: ").strip()
+    return val or default
+
+
+def prompt_yes_no(prompt_text: str, default_yes: bool = True) -> bool:
+    default = "Y/n" if default_yes else "y/N"
+    while True:
+        ans = input(f"{prompt_text} ({default}): ").strip().lower()
+        if not ans:
+            return default_yes
+        if ans in ("y", "yes"):
+            return True
+        if ans in ("n", "no"):
+            return False
+        print("Please answer y or n.")
+
+
+def is_probably_path(value: str) -> bool:
+    if not isinstance(value, str):
+        return False
+    v = value.strip()
+    if not v:
+        return False
+    if "://" in v or v.startswith("@"):
+        return False
+    looks_like_path = (
+        "\\" in v
+        or "/" in v
+        or os.path.splitext(v)[1].lower()
+        in {".json", ".yml", ".yaml", ".bonsai", ".csv", ".txt", ".exe"}
+    )
+    return looks_like_path
+
+
+def make_relative_if_under_root(path_abs: str, root_abs: str) -> str:
+    path_abs = norm(path_abs)
+    root_abs = norm(root_abs)
+    try:
+        rel = os.path.relpath(path_abs, root_abs)
+        if not rel.startswith(".."):
+            return rel.replace("\\", "/")
+    except Exception:
+        pass
+    return path_abs.replace("\\", "/")
+
+
+# -------------------------------
+# Session helpers
+# -------------------------------
+def utc_timestamp_for_session() -> str:
+    return datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H-%M-%S"
+    )  # e.g., 2025-05-09T18-46-21
+
+
+def build_session(exp_key: str, experimenter_default: str = "") -> Dict[str, Any]:
+    experimenter = prompt("Experimenter name", default=experimenter_default)
+    subject_id = prompt("Subject ID")
+    return build_session_with_values(exp_key, experimenter, subject_id)
+
+
+def build_session_with_values(
+    exp_key: str, experimenter: str, subject_id: str, start_utc: str = ""
+) -> Dict[str, Any]:
+    experiment_name = exp_key.lower()
+    if not start_utc:
+        start_utc = utc_timestamp_for_session()
+    session_id = f"{experiment_name}_{subject_id}_{start_utc}".replace(" ", "_")
+    return {
+        "session_id": session_id,
+        "experimenter": experimenter,
+        "subject_id": subject_id,
+        "experiment_name": experiment_name,
+        "start_utc": start_utc,
+        "experiment_key": exp_key,
+    }
+
+
+def save_session_record(session: Dict[str, Any]) -> Path:
+    try:
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        safe_exp = session.get("experiment_name", "exp")
+        safe_subj = (session.get("subject_id", "subj") or "").replace(" ", "_")
+        fp = (
+            SESSIONS_DIR / f"session_{session['start_utc']}_{safe_exp}_{safe_subj}.json"
+        )
+        with open(fp, "w", encoding="utf-8") as f:
+            json.dump(session, f, indent=2, ensure_ascii=False)
+        return fp
+    except Exception as e:
+        print(f"Warning: Could not write session log: {e}")
+        return Path()
+
+
+# -------------------------------
+# Experiment selection (interactive)
+# -------------------------------
+def select_experiments(cfg: Dict[str, Any]) -> List[str]:
+    experiments = cfg["EXPERIMENTS"]
+    keys = sorted(experiments.keys())
+    print("\n=== Select Experiments ===")
+    for i, k in enumerate(keys, start=1):
+        print(f"  {i}. {k} — {experiments[k].get('name', '')}")
+    print("  all. All experiments")
+
+    while True:
+        raw = input("Enter numbers/names (comma-separated), or 'all': ").strip()
+        if not raw:
+            print("Please enter a selection.")
+            continue
+
+        if raw.lower() == "all":
+            return keys
+
+        chosen: List[str] = []
+        tokens = [t.strip() for t in raw.replace(";", ",").split(",") if t.strip()]
+        ok = True
+        for t in tokens:
+            if t.isdigit():
+                i = int(t)
+                if 1 <= i <= len(keys):
+                    chosen.append(keys[i - 1])
+                else:
+                    ok = False
+                    break
+            else:
+                match = [k for k in keys if k.lower() == t.lower()]
+                if match:
+                    chosen.append(match[0])
+                else:
+                    ok = False
+                    print(f"Unknown experiment: {t}")
+                    break
+        if ok and chosen:
+            # preserve order, de-dupe
+            result = []
+            seen = set()
+            for k in chosen:
+                if k not in seen:
+                    seen.add(k)
+                    result.append(k)
+            return result
+        print("Invalid selection. Try again.")
+
+
+# -------------------------------
+# Workflow roots & workflows
+# -------------------------------
+def ensure_workflow_root(exp_key: str, exp: Dict[str, Any], cfg: Dict[str, Any]) -> str:
+    experiments = cfg["EXPERIMENTS"]
+    roots = exp.get("WorkflowRoot", [])
+    if not isinstance(roots, list):
+        roots = [roots]
+
+    if not roots:
+        print("No WorkflowRoot configured. Let's add one.")
+
+    while True:
+        options = (
+            [f"{r} {'(found)' if exists_path(r) else '(missing)'}" for r in roots]
+            if roots
+            else []
+        )
+        options.append("Add a new WorkflowRoot...")
+        print("\nSelect a WorkflowRoot")
+        for i, opt in enumerate(options, start=1):
+            print(f"  {i}. {opt}")
+        raw = input("Enter number: ").strip()
+        if not raw.isdigit():
+            print("Invalid selection. Try again.")
+            continue
+        idx = int(raw) - 1
+
+        if idx == len(options) - 1:
+            new_root = prompt("Enter full path to WorkflowRoot (folder)")
+            if not exists_path(new_root):
+                print("That path does not exist. Please try again.")
+                continue
+            new_root = norm(new_root)
+            if new_root not in roots:
+                roots.append(new_root)
+                exp["WorkflowRoot"] = [r.replace("\\", "/") for r in roots]
+                experiments[exp_key] = exp
+                cfg["EXPERIMENTS"] = experiments
+                save_config(cfg)
+            return new_root
+        else:
+            if 0 <= idx < len(roots):
+                chosen = roots[idx]
+                if exists_path(chosen):
+                    return norm(chosen)
+                else:
+                    print(
+                        "Selected root path does not exist. Choose another or add a new one."
+                    )
+            else:
+                print("Invalid selection. Try again.")
+
+
+def ensure_workflows(
+    exp_key: str, exp: Dict[str, Any], chosen_root: str, cfg: Dict[str, Any]
+) -> List[str]:
+    """
+    Show available workflows, let the user select one by number or enter a new path.
+    Returns a one-element list with the absolute selected workflow path.
+    """
+    experiments = cfg["EXPERIMENTS"]
+    wf_list = exp.get("workflows", [])
+    if not isinstance(wf_list, list):
+        wf_list = []
+        exp["workflows"] = wf_list
+
+    def to_abs(wf_entry: str) -> str:
+        if not wf_entry:
+            return ""
+        return norm(
+            wf_entry
+            if os.path.isabs(wf_entry)
+            else os.path.join(chosen_root, wf_entry.lstrip("\\/"))
+        )
+
+    while True:
+        print("\nAvailable workflows for this experiment:")
+        if wf_list:
+            for idx, wf in enumerate(wf_list, start=1):
+                abs_candidate = to_abs(wf)
+                status = "[OK]" if exists_path(abs_candidate) else "[MISSING]"
+                print(f"  {idx}. {wf}  {status}")
+        else:
+            print("  (none yet)")
+        print(f"  {len(wf_list) + 1}. Enter a new workflow path...")
+
+        sel_raw = input("Choose a workflow by number, or enter a new path: ").strip()
+
+        if sel_raw.isdigit():
+            sel = int(sel_raw)
+            if 1 <= sel <= len(wf_list):
+                chosen_entry = wf_list[sel - 1]
+                chosen_abs = to_abs(chosen_entry)
+                if not exists_path(chosen_abs):
+                    print(f"\nSelected workflow does not exist:\n  {chosen_abs}")
+                    print(
+                        "Please fix it by entering a new path, or choose another entry."
+                    )
+                    continue
+                return [chosen_abs]
+            elif sel == len(wf_list) + 1:
+                pass
+            else:
+                print("Invalid selection. Try again.")
+                continue
+
+        if not sel_raw:
+            print("A workflow selection or path is required. Try again.")
+            continue
+
+        new_path = sel_raw
+        if not os.path.isabs(new_path):
+            new_path = os.path.join(chosen_root, new_path.lstrip("\\/"))
+        new_path = norm(new_path)
+
+        if not exists_path(new_path):
+            print("That path does not exist. Try again.")
+            continue
+
+        stored = make_relative_if_under_root(new_path, chosen_root)
+        if stored not in wf_list:
+            wf_list.append(stored)
+            exp["workflows"] = wf_list
+            experiments[exp_key] = exp
+            cfg["EXPERIMENTS"] = experiments
+            save_config(cfg)
+            print(f"Added workflow: {stored}")
+        return [new_path]
+
+
+# -------------------------------
+# Parameter editor (persisted)
+# -------------------------------
+def prompt_parameters_menu(
+    exp_key: str, exp: Dict[str, Any], chosen_root: str, cfg: Dict[str, Any]
+) -> None:
+    experiments = cfg["EXPERIMENTS"]
+    params = exp.get("parameters", {}) or {}
+    if not isinstance(params, dict):
+        exp["parameters"] = {}
+        params = exp["parameters"]
+
+    param_opts: Dict[str, List[str]] = exp.get("ParameterOptions", {}) or {}
+    if not isinstance(param_opts, dict):
+        exp["ParameterOptions"] = {}
+        param_opts = exp["ParameterOptions"]
+
+    def persist():
+        experiments[exp_key] = exp
+        cfg["EXPERIMENTS"] = experiments
+        save_config(cfg)
+
+    def to_abs(p: str) -> str:
+        if not p:
+            return ""
+        return norm(
+            p if os.path.isabs(p) else os.path.join(chosen_root, p.lstrip("\\/"))
+        )
+
+    def add_option(name: str, stored_value: str) -> None:
+        if not stored_value:
+            return
+        lst = param_opts.get(name, [])
+        if stored_value not in lst:
+            lst.append(stored_value)
+            param_opts[name] = lst
+            exp["ParameterOptions"] = param_opts
+
+    def store_pathlike(value_raw: str) -> str:
+        v = value_raw.strip()
+        if (not is_probably_path(v)) or "://" in v or v.startswith("@"):
+            return v
+        candidate_abs = to_abs(v)
+        if exists_path(candidate_abs):
+            return make_relative_if_under_root(candidate_abs, chosen_root)
+        return v
+
+    def choose_value_for_parameter(name: str) -> None:
+        current_v = params.get(name, "")
+        saved_list = list(param_opts.get(name, []) or [])
+        if current_v and current_v not in saved_list:
+            saved_list.insert(0, current_v)
+
+        while True:
+            print(f"\nParameter: {name}")
+            if saved_list:
+                for i, v in enumerate(saved_list, start=1):
+                    is_pathlike = (
+                        is_probably_path(v) and "://" not in v and not v.startswith("@")
+                    )
+                    preview = to_abs(v) if is_probably_path(v) else v
+                    status = (
+                        " [OK]"
+                        if (is_probably_path(v) and exists_path(preview))
+                        else (" [MISSING]" if is_probably_path(v) else "")
+                    )
+                    tag = " [current]" if v == current_v else ""
+                    print(f"  {i}. {v}{tag}{status}")
+            else:
+                print("  (no saved values yet)")
+            new_idx = len(saved_list) + 1
+            rm_idx = new_idx + 1 if saved_list else new_idx
+            back_idx = rm_idx + 1 if saved_list else new_idx
+
+            print(f"  {new_idx}. Enter a new value...")
+            if saved_list:
+                print(f"  {rm_idx}. Remove a saved value...")
+            print(f"  {back_idx}. Back")
+
+            sel = input("Choose by number, or type a new value directly: ").strip()
+
+            if sel and not sel.isdigit():
+                new_raw = sel
+                stored = store_pathlike(new_raw)
+                params[name] = stored
+                add_option(name, stored)
+                persist()
+                return
+
+            if not sel.isdigit():
+                print("Invalid selection. Try again.")
+                continue
+
+            sel_i = int(sel)
+
+            if 1 <= sel_i <= len(saved_list):
+                chosen = saved_list[sel_i - 1]
+                stored = store_pathlike(chosen)
+                params[name] = stored
+                add_option(name, stored)
+                persist()
+                return
+
+            if sel_i == new_idx:
+                new_raw = prompt("New value", default="")
+                if not new_raw:
+                    continue
+                stored = store_pathlike(new_raw)
+                params[name] = stored
+                add_option(name, stored)
+                persist()
+                return
+
+            if saved_list and sel_i == rm_idx:
+                print("\nSelect a value to remove from saved options:")
+                for i, v in enumerate(saved_list, start=1):
+                    print(f"  {i}. {v}")
+                raw_rm = input("Enter number to remove (or blank to cancel): ").strip()
+                if raw_rm.isdigit():
+                    rm_i = int(raw_rm)
+                    if 1 <= rm_i <= len(saved_list):
+                        victim = saved_list[rm_i - 1]
+                        if victim == current_v:
+                            print(
+                                "Cannot remove the current value. Switch current first."
+                            )
+                        else:
+                            opts = param_opts.get(name, [])
+                            if victim in opts:
+                                opts.remove(victim)
+                                param_opts[name] = opts
+                                exp["ParameterOptions"] = param_opts
+                                persist()
+                                print("Removed.")
+                continue
+
+            if sel_i == back_idx:
+                return
+
+            print("Invalid selection. Try again.")
+
+    while True:
+        param_names = sorted(params.keys())
+        print("\n=== Parameter Editor ===")
+        if param_names:
+            for i, name in enumerate(param_names, start=1):
+                print(f"  {i}. {name}  [current={params.get(name, '')}]")
+        else:
+            print("  (no parameters yet)")
+
+        add_idx = len(param_names) + 1
+        done_idx = add_idx + 1
+        print(f"  {add_idx}. Add a new parameter...")
+        print(f"  {done_idx}. Done")
+
+        sel = input(
+            "Choose a parameter by number, or press Enter to add a new one: "
+        ).strip()
+        if not sel:
+            sel = str(add_idx)
+
+        if sel.isdigit():
+            sel_i = int(sel)
+            if 1 <= sel_i <= len(param_names):
+                choose_value_for_parameter(param_names[sel_i - 1])
+                continue
+            if sel_i == add_idx:
+                while True:
+                    name = prompt(
+                        "New parameter name (e.g., RuleSettings)", default=""
+                    ).strip()
+                    if not name:
+                        print("A parameter name is required.")
+                        continue
+                    break
+                initial = prompt(
+                    "Initial value (absolute/relative path, URL, or connection string)",
+                    default="",
+                ).strip()
+                if initial:
+                    if is_probably_path(initial):
+                        initial_abs = (
+                            norm(os.path.join(chosen_root, initial.lstrip("\\/")))
+                            if not os.path.isabs(initial)
+                            else norm(initial)
+                        )
+                        stored = (
+                            make_relative_if_under_root(initial_abs, chosen_root)
+                            if exists_path(initial_abs)
+                            else initial
+                        )
+                    else:
+                        stored = initial
+                    exp["parameters"][name] = stored
+                    lst = param_opts.get(name, [])
+                    if stored not in lst:
+                        lst.append(stored)
+                        param_opts[name] = lst
+                    persist()
+                else:
+                    exp["parameters"][name] = ""
+                    persist()
+                continue
+            if sel_i == done_idx:
+                print("Parameter edits complete.")
+                return
+
+        print("Invalid selection. Try again.")
+
+
+# -------------------------------
+# Lifealert options menu (persisted)
+# -------------------------------
+def lifealert_options_menu(
+    pir_exp: Dict[str, Any], pir_root: str, cfg: Dict[str, Any]
+) -> str:
+    experiments = cfg["EXPERIMENTS"]
+    params = pir_exp.get("parameters", {}) or {}
+    options = pir_exp.get("LifealertOptions", []) or []
+    current = params.get("LifealertRoot", "")
+
+    def persist():
+        pir_exp["parameters"] = params
+        pir_exp["LifealertOptions"] = options
+        experiments["Pirouette"] = pir_exp
+        cfg["EXPERIMENTS"] = experiments
+        save_config(cfg)
+
+    def to_abs(p: str) -> str:
+        if not p:
+            return ""
+        return norm(p if os.path.isabs(p) else os.path.join(pir_root, p.lstrip("\\/")))
+
+    while True:
+        print("\n=== Lifealert Directory ===")
+        if options:
+            for i, v in enumerate(options, start=1):
+                tag = " [current]" if v == current else ""
+                print(f"  {i}. {v}{tag}")
+        else:
+            print("  (no saved Lifealert paths yet)")
+        add_i = len(options) + 1
+        back_i = add_i + 1
+        print(f"  {add_i}. Enter a new path...")
+        print(f"  {back_i}. Back")
+
+        sel = input("Choose by number, or type a new path directly: ").strip()
+
+        if sel and not sel.isdigit():
+            newp = sel
+            selected_abs = to_abs(newp)
+            if exists_path(selected_abs):
+                stored = make_relative_if_under_root(selected_abs, pir_root)
+            else:
+                stored = newp
+            params["LifealertRoot"] = stored
+            if stored not in options:
+                options.append(stored)
+            persist()
+            return selected_abs
+
+        if not sel.isdigit():
+            print("Invalid selection. Try again.")
+            continue
+
+        si = int(sel)
+        if 1 <= si <= len(options):
+            stored = options[si - 1]
+            selected_abs = to_abs(stored)
+            params["LifealertRoot"] = stored
+            persist()
+            return selected_abs
+
+        if si == add_i:
+            newp = prompt("New Lifealert directory", default="").strip()
+            if not newp:
+                continue
+            selected_abs = to_abs(newp)
+            if exists_path(selected_abs):
+                stored = make_relative_if_under_root(selected_abs, pir_root)
+            else:
+                stored = newp
+            params["LifealertRoot"] = stored
+            if stored not in options:
+                options.append(stored)
+            persist()
+            return selected_abs
+
+        if si == back_i:
+            return ""
+
+        print("Invalid selection. Try again.")
+
+
+# -------------------------------
+# Parameter expansion to absolute for launch
+# -------------------------------
+def expand_and_validate_parameters(
+    exp_key: str, exp: Dict[str, Any], chosen_root: str, cfg: Dict[str, Any]
+) -> Dict[str, str]:
+    params = exp.get("parameters", {}) or {}
+    final_params: Dict[str, str] = {}
+
+    for k, v in params.items():
+        if isinstance(v, str) and is_probably_path(v):
+            candidate = (
+                v if os.path.isabs(v) else os.path.join(chosen_root, v.lstrip("\\/"))
+            )
+            candidate = norm(candidate)
+            if "://" not in v and not v.startswith("@"):
+                final_params[k] = candidate
+            else:
+                final_params[k] = v
+        else:
+            final_params[k] = v
+
+    return final_params
+
+
+# -------------------------------
+# Resolve Bonsai exe path
+# -------------------------------
+def resolve_bonsai_cmd(
+    exp_key: str, exp: Dict[str, Any], chosen_root: str, cfg: Dict[str, Any]
+) -> str:
+    rel_cmd = (exp.get("BONSAI_CMD") or "").strip()
+
+    def _full(p: str) -> str:
+        return norm(
+            p if os.path.isabs(p) else os.path.join(chosen_root, p.lstrip("\\/"))
+        )
+
+    if rel_cmd:
+        full = _full(rel_cmd)
+        if exists_path(full):
+            return full
+        else:
+            print(f"\nBonsai executable not found at: {full}")
+    else:
+        print("\nNo BONSAI_CMD set for this experiment yet.")
+
+    while True:
+        new_val = prompt(
+            "Enter path to Bonsai executable (absolute or RELATIVE to the chosen WorkflowRoot)"
+        )
+        if not new_val:
+            print("A path is required.")
+            continue
+        full = _full(new_val)
+        if not exists_path(full):
+            print("That path does not exist. Please try again.")
+            continue
+
+        stored = make_relative_if_under_root(full, chosen_root)
+        exp["BONSAI_CMD"] = stored
+        cfg["EXPERIMENTS"][exp_key] = exp
+        save_config(cfg)
+        return full
+
+
+# -------------------------------
+# Pirouette recovery temp files
+# -------------------------------
+def zero_pirouette_temp_files(chosen_root: str) -> None:
+    src_dir = Path(chosen_root) / "src"
+    filenames = [
+        "~AccumulatedCommutatorTurnsRecovery.Double.tmp",
+        "~AccumulatedMagnetTurnsRecovery.Double.tmp",
+        "~SampleIndexRecovery.Int64.tmp",
+    ]
+    for name in filenames:
+        fpath = src_dir / name
+        if fpath.exists():
+            try:
+                with open(fpath, "w", encoding="utf-8") as f:
+                    f.write("0")
+                if str(fpath) not in TEMP_SESSION_FILES:
+                    TEMP_SESSION_FILES.append(str(fpath))
+                print(f"Reset temp file: {fpath}")
+            except Exception as e:
+                print(f"Warning: could not reset {fpath}: {e}")
+
+
+# -------------------------------
+# Per-session schema copies
+# -------------------------------
+def copy_and_patch_hardware_schema(
+    src_abs: str, subject_id: str, start_utc_hyphen: str
+) -> str:
+    src = Path(src_abs)
+    parent = src.parent
+    stem = src.stem
+    ext = src.suffix or ".yml"
+    dst = parent / f"{stem}_{subject_id}_{start_utc_hyphen}{ext}"
+
+    try:
+        text = src.read_text(encoding="utf-8") if src.exists() else ""
+    except Exception:
+        text = ""
+
+    def upsert_line(content: str, key: str, value: str) -> str:
+        pattern = re.compile(rf"^(?P<prefix>{re.escape(key)}\s*:\s*).*$", re.MULTILINE)
+        if pattern.search(content):
+            return pattern.sub(rf"\g<prefix>{value}", content)
+        else:
+            return f"{key}: {value}\n" + content
+
+    text = upsert_line(text, "subject_id", f"'{subject_id}'")
+    text = upsert_line(text, "session_time", f"'{start_utc_hyphen}'")
+
+    try:
+        dst.write_text(text, encoding="utf-8")
+        TEMP_SESSION_FILES.append(str(dst))
+    except Exception as e:
+        print(f"Warning: could not write patched hardware schema: {e}")
+    return str(dst)
+
+
+def copy_and_patch_aind_session_json(
+    src_abs: str,
+    subject_id: str,
+    start_utc_hyphen: str,
+    experimenter: str,
+    experiment_value: str,
+) -> str:
+    src = Path(src_abs)
+    parent = src.parent
+    stem = src.stem
+    ext = src.suffix or ".json"
+    dst = parent / f"{stem}_{subject_id}_{start_utc_hyphen}{ext}"
+
+    obj: Dict[str, Any] = {}
+    if src.exists():
+        try:
+            obj = json.loads(src.read_text(encoding="utf-8"))
+        except Exception:
+            obj = {}
+
+    obj["subject"] = subject_id
+    obj["date"] = start_utc_hyphen  # hyphen UTC
+    obj["session_name"] = f"{subject_id}_{start_utc_hyphen}"
+    obj["experimenter"] = [experimenter] if experimenter else []
+    obj["experiment"] = experiment_value
+
+    try:
+        dst.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+        TEMP_SESSION_FILES.append(str(dst))
+    except Exception as e:
+        print(f"Warning: could not write patched AIND session JSON: {e}")
+    return str(dst)
+
+
+# -------------------------------
+# Named per-session overrides helper (define BEFORE use)
+# -------------------------------
+def build_session_overrides_if_available(
+    exp: Dict[str, Any], session: Dict[str, Any]
+) -> Dict[str, str]:
+    """
+    If the experiment config includes parameter names like 'Experimenter', 'SubjectId',
+    'SessionId', 'SessionStartUtc', 'ExperimentName', prepare per-session overrides.
+    """
+    param_names = set((exp.get("parameters") or {}).keys())
+    overrides = {}
+    mapping = [
+        ("Experimenter", "experimenter"),
+        ("SubjectId", "subject_id"),
+        ("SessionId", "session_id"),
+        ("SessionStartUtc", "start_utc"),
+        ("ExperimentName", "experiment_name"),
+    ]
+    for pname, sname in mapping:
+        if pname in param_names:
+            overrides[pname] = str(session.get(sname, ""))
+    return overrides
+
+
+# -------------------------------
+# Per-session parameter override menu (session-only)
+# -------------------------------
+def prompt_per_session_overrides(
+    exp: Dict[str, Any], chosen_root: str, base_params_abs: Dict[str, str]
+) -> Dict[str, str]:
+    params = dict(base_params_abs)
+    param_opts: Dict[str, List[str]] = exp.get("ParameterOptions", {}) or {}
+
+    def to_abs(v: str) -> str:
+        if not v:
+            return v
+        return norm(
+            v if os.path.isabs(v) else os.path.join(chosen_root, v.lstrip("\\/"))
+        )
+
+    while True:
+        names = sorted(params.keys())
+        print("\n=== Per-Session Overrides ===")
+        for i, k in enumerate(names, start=1):
+            print(f"  {i}. {k}  [current={params[k]}]")
+        add_i = len(names) + 1
+        done_i = add_i + 1
+        print(f"  {add_i}. Enter a new override (name=value)")
+        print(f"  {done_i}. Done")
+
+        sel = input(
+            "Pick a parameter by number to override, or choose an option: "
+        ).strip()
+        if not sel.isdigit():
+            print("Invalid selection. Try again.")
+            continue
+
+        sel_i = int(sel)
+        if 1 <= sel_i <= len(names):
+            k = names[sel_i - 1]
+            options = param_opts.get(k, [])
+            if options:
+                print(f"\nSaved values for '{k}':")
+                for j, opt in enumerate(options, start=1):
+                    preview = to_abs(opt) if is_probably_path(opt) else opt
+                    status = ""
+                    if (
+                        is_probably_path(opt)
+                        and "://" not in opt
+                        and not opt.startswith("@")
+                    ):
+                        status = " [OK]" if exists_path(preview) else " [MISSING]"
+                    print(f"  {j}. {opt}{status}")
+                print(f"  {len(options) + 1}. Enter a new value...")
+                raw = input("Choose by number or type a new value: ").strip()
+                if raw.isdigit():
+                    r = int(raw)
+                    if 1 <= r <= len(options):
+                        val = options[r - 1]
+                        params[k] = to_abs(val) if is_probably_path(val) else val
+                        continue
+                    elif r == len(options) + 1:
+                        pass
+                    else:
+                        print("Invalid selection.")
+                        continue
+                newv = (
+                    raw if raw and not raw.isdigit() else input("New value: ").strip()
+                )
+            else:
+                newv = input(f"New value for '{k}': ").strip()
+
+            if newv:
+                params[k] = to_abs(newv) if is_probably_path(newv) else newv
+            continue
+
+        if sel_i == add_i:
+            raw = input("Enter name=value: ").strip()
+            if "=" not in raw:
+                print("Please use the format name=value.")
+                continue
+            name, value = raw.split("=", 1)
+            name = name.strip()
+            value = value.strip()
+            params[name] = to_abs(value) if is_probably_path(value) else value
+            continue
+
+        if sel_i == done_i:
+            return params
+
+        print("Invalid selection. Try again.")
+
+
+# -------------------------------
+# Launch utilities
+# -------------------------------
+def prompt_launch_mode() -> bool:
+    while True:
+        ans = (
+            input("\nStart workflow now or open in editor? [S]tart / [O]pen: ")
+            .strip()
+            .lower()
+        )
+        if ans in ("s", "start"):
+            return True
+        if ans in ("o", "open"):
+            return False
+        print("Please type 'S' to Start or 'O' to Open.")
+
+
+def prompt_run_mode() -> bool:
+    while True:
+        ans = (
+            input("Run all sessions [S]equentially or in [P]arallel? ").strip().lower()
+        )
+        if ans in ("s", "seq", "sequential", "sequentially"):
+            return False
+        if ans in ("p", "par", "parallel"):
+            return True
+        print("Please type 'S' for sequential or 'P' for parallel.")
+
+
+# ---- NEW: filter out non-Bonsai meta-parameters (e.g., LifealertRoot) ----
+def filter_params_for_bonsai(parameters: Dict[str, str]) -> Dict[str, str]:
+    """Return a copy of params excluding keys that should NOT be passed to Bonsai."""
+    EXCLUDE = {"lifealertroot"}  # case-insensitive
+    return {k: v for k, v in parameters.items() if k.lower() not in EXCLUDE}
+
+
+def launch_bonsai(
+    bonsai_cmd_full: str,
+    workflow_path: str,
+    parameters: Dict[str, str],
+    auto_start: bool,
+) -> subprocess.Popen:
+    cmd = [bonsai_cmd_full, workflow_path]
+    if auto_start:
+        cmd.append("--start")
+    # Filter out LifealertRoot (and any future non-Bonsai meta keys)
+    safe_params = filter_params_for_bonsai(parameters)
+    for k, v in safe_params.items():
+        cmd.extend(["-p", f"{k}={v}"])  # Bonsai uses -p Name=Value
+    print("\nLaunching:", " ".join(cmd))
+    try:
+        return subprocess.Popen(cmd)  # shell=False, argv list
+    except FileNotFoundError:
+        print(
+            "Error: Could not start Bonsai. Verify BONSAI_CMD for this experiment in the config."
+        )
+        sys.exit(1)
+
+
+def stop_lifealert():
+    if not LIFEALERT_PROCS:
+        print("No lifealert process is currently running.")
+        return
+    print("Stopping lifealert processes...")
+    for p in LIFEALERT_PROCS:
+        try:
+            p.terminate()
+        except Exception:
+            pass
+    LIFEALERT_PROCS.clear()
+    print("lifealert stopped.")
+
+
+def start_lifealert_with_menu(
+    cfg: Dict[str, Any], prepared_per_experiment: Dict[str, Dict[str, Any]]
+) -> None:
+    if "Pirouette" not in cfg["EXPERIMENTS"]:
+        print("Pirouette is not configured; cannot start lifealert.")
+        return
+    pir_info = prepared_per_experiment.get("Pirouette")
+    if not pir_info:
+        print("Pirouette was not selected for this run; cannot start lifealert.")
+        return
+    pir_exp = cfg["EXPERIMENTS"]["Pirouette"]
+    pir_root = pir_info["root"]
+    choose_abs = lifealert_options_menu(pir_exp, pir_root, cfg)
+    if not choose_abs:
+        print("No lifealert directory chosen.")
+        return
+    if not exists_path(choose_abs):
+        print(f"Selected lifealert directory does not exist: {choose_abs}")
+        return
+    try:
+        print(f"Starting lifealert in: {choose_abs}")
+        p = subprocess.Popen(["uv", "run", "lifealert"], cwd=norm(choose_abs))
+        LIFEALERT_PROCS.append(p)
+        print("lifealert started.")
+    except FileNotFoundError:
+        print("Could not start lifealert: 'uv' not found on PATH.")
+    except Exception as e:
+        print(f"Could not start lifealert: {e}")
+
+
+def show_status():
+    print("\n=== Status ===")
+    if WORKFLOW_PROCS:
+        alive = 0
+        for i, p in enumerate(WORKFLOW_PROCS, start=1):
+            code = p.poll()
+            state = "RUNNING" if code is None else f"EXITED({code})"
+            print(f"  Workflow[{i}]: PID={p.pid} {state}")
+            if code is None:
+                alive += 1
+        if alive == 0:
+            print("  All workflow processes have exited.")
+    else:
+        print("  No workflow processes launched.")
+
+    if LIFEALERT_PROCS:
+        for i, p in enumerate(LIFEALERT_PROCS, start=1):
+            code = p.poll()
+            state = "RUNNING" if code is None else f"EXITED({code})"
+            print(f"  lifealert[{i}]: PID={p.pid} {state}")
+    else:
+        print("  lifealert: not running.")
+
+
+def wait_for_workflows():
+    if not WORKFLOW_PROCS:
+        print("No workflow processes to wait for.")
+        return
+    print("Waiting for all workflow processes to finish (Ctrl+C to abort waiting)...")
+    try:
+        for p in WORKFLOW_PROCS:
+            p.wait()
+    except KeyboardInterrupt:
+        print("\nStopped waiting. Workflows may still be running.")
+
+
+def cleanup_temp_files_and_processes():
+    if TEMP_SESSION_FILES:
+        print("\nCleaning up per-session override and temp files:")
+        for fp in TEMP_SESSION_FILES:
+            try:
+                Path(fp).unlink(missing_ok=True)
+                print(f"  removed: {fp}")
+            except Exception as e:
+                print(f"  warning: could not remove {fp}: {e}")
+    if LIFEALERT_PROCS:
+        print("\nStopping lifealert processes...")
+        for p in LIFEALERT_PROCS:
+            try:
+                p.terminate()
+            except Exception:
+                pass
+        LIFEALERT_PROCS.clear()
+
+
+# -------------------------------
+# Pre-launch SUMMARY (hides LifealertRoot)
+# -------------------------------
+def print_prelaunch_summary(
+    sessions_to_launch: List[Dict[str, Any]], auto_start: bool, parallel: bool
+):
+    print("\n==================== PRE-LAUNCH SUMMARY ====================")
+    print(f"Mode      : {'START (run)' if auto_start else 'OPEN (editor)'}")
+    print(f"Scheduling: {'PARALLEL' if parallel else 'SEQUENTIAL'}")
+    print("------------------------------------------------------------")
+    for idx, s in enumerate(sessions_to_launch, start=1):
+        sess = s["session"]
+        print(
+            f"[{idx}] Experiment: {sess['experiment_name']} | Experimenter={sess['experimenter']} | Subject={sess['subject_id']} | Start={sess['start_utc']}"
+        )
+        print(f"     Workflow : {s['workflow']}")
+        print("     Parameters:")
+        # Show only the params that will be passed to Bonsai (filter out LifealertRoot)
+        display_params = filter_params_for_bonsai(s["params"])
+        for k, v in sorted(display_params.items()):
+            print(f"       - {k}: {v}")
+    print("============================================================")
+
+
+# -------------------------------
+# Profile loading (JSON/YAML)
+# -------------------------------
+def resolve_profile_path(name_or_file: str) -> Optional[Path]:
+    if not name_or_file:
+        return None
+    p = Path(name_or_file)
+    if p.suffix.lower() in (".json", ".yaml", ".yml"):
+        return p if p.exists() else None
+    # treat as NAME
+    candidates = [
+        EXPERIMENTS_DIR / f"{name_or_file}.json",
+        EXPERIMENTS_DIR / f"{name_or_file}.yaml",
+        EXPERIMENTS_DIR / f"{name_or_file}.yml",
+    ]
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    return None
+
+
+def load_profile(path: Path) -> Dict[str, Any]:
+    if path.suffix.lower() == ".json":
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    # YAML
+    if path.suffix.lower() in (".yaml", ".yml"):
+        if yaml is None:
+            raise RuntimeError(
+                "YAML profile provided but PyYAML is not available. Use JSON or install PyYAML."
+            )
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    raise RuntimeError(f"Unsupported profile extension: {path.suffix}")
+
+
+def apply_profile_to_config(
+    profile: Dict[str, Any], cfg: Dict[str, Any]
+) -> Tuple[List[str], Optional[bool], Optional[bool]]:
+    experiments = cfg["EXPERIMENTS"]
+    # Selected experiments
+    selected = profile.get("experiments", [])
+    if isinstance(selected, str) and selected.lower() == "all":
+        selected_keys = sorted(experiments.keys())
+    elif isinstance(selected, list) and selected:
+        selected_keys = []
+        for k in selected:
+            if k in experiments:
+                selected_keys.append(k)
+            else:
+                print(
+                    f"Warning: profile references unknown experiment '{k}'. Skipping."
+                )
+        if not selected_keys:
+            selected_keys = sorted(experiments.keys())
+    else:
+        selected_keys = sorted(experiments.keys())
+
+    # Apply per-experiment config
+    per = profile.get("experiments_config", {}) or {}
+    for k, exp_override in per.items():
+        if k not in experiments:
+            print(
+                f"Warning: profile experiments_config has unknown experiment '{k}'. Skipping."
+            )
+            continue
+        exp = experiments[k]
+
+        # Set root
+        root = exp_override.get("root")
+        if root:
+            exp["WorkflowRoot"] = [root]
+
+        # Set workflow
+        wf = exp_override.get("workflow")
+        if wf:
+            exp["workflows"] = [wf]
+
+        # Set parameters (merge/replace)
+        params = exp_override.get("parameters", {})
+        if params and isinstance(params, dict):
+            base_params = exp.get("parameters", {}) or {}
+            base_params.update(params)
+            exp["parameters"] = base_params
+
+        experiments[k] = exp
+
+    auto_start = profile.get("auto_start")
+    parallel = profile.get("parallel")
+    return selected_keys, auto_start, parallel
+
+
+# -------------------------------
+# Session planning (interactive or profile)
+# -------------------------------
+def plan_sessions_for_experiment(
+    exp_key: str, profile_session_count: int = None
+) -> int:
+    """
+    Determine how many sessions to run for this experiment.
+
+    - If 'profile_session_count' is provided (from a profile .json/.yaml), return it directly.
+    - Otherwise, interactive prompt: ask the user.
+    """
+
+    # Profile override
+    if profile_session_count is not None:
+        if isinstance(profile_session_count, int) and profile_session_count >= 1:
+            return profile_session_count
+        else:
+            print(
+                f"Warning: Profile session_count for '{exp_key}' is invalid; defaulting to 1."
+            )
+            return 1
+
+    # Interactive prompt mode
+    while True:
+        raw = input(f"\nHow many sessions for '{exp_key}'? [1]: ").strip()
+        if not raw:
+            return 1
+        if raw.isdigit() and int(raw) >= 1:
+            return int(raw)
+        print("Please enter an integer >= 1.")
+
+
+def apply_per_session_profile_parameters(
+    exp_key: str, profile: dict, session_index: int
+) -> dict:
+    """
+    Reads experiments_config[exp_key].session_parameters[session_index]
+    Returns {} if none exist.
+    """
+    exp_cfg = profile.get("experiments_config", {}).get(exp_key, {})
+    sess_params = exp_cfg.get("session_parameters", [])
+    if isinstance(sess_params, list) and 0 <= session_index < len(sess_params):
+        entry = sess_params[session_index]
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
+# -------------------------------
+# Main
+# -------------------------------
+def main():
+    args = parse_args()
+
+    cfg = load_config()
+    experiments = cfg.get("EXPERIMENTS", {})
+    if not experiments:
+        print("No experiments configured yet in launcher_config.json.")
+        sys.exit(0)
+
+    # (0) Profile?
+    profile = None
+    auto_start_from_profile = None
+    parallel_from_profile = None
+
+    if args.experiment:
+        profile_path = resolve_profile_path(args.experiment)
+        if not profile_path:
+            print(f"Could not find profile: {args.experiment}")
+            sys.exit(1)
+        try:
+            profile = load_profile(profile_path)
+            selected_keys, auto_start_from_profile, parallel_from_profile = (
+                apply_profile_to_config(profile, cfg)
+            )
+            print(f"Loaded profile: {profile_path}")
+        except Exception as e:
+            print(f"Error loading profile: {e}")
+            sys.exit(1)
+    else:
+        selected_keys = select_experiments(cfg)
+
+    # Determine "all experiments"
+    all_keys_sorted = sorted(experiments.keys())
+    selected_is_all = set(selected_keys) == set(all_keys_sorted)
+
+    # Prepare each experiment
+    prepared_per_experiment = {}
+
+    for exp_key in selected_keys:
+        exp = experiments[exp_key]
+        print(f"\n--- Configure: {exp_key} — {exp.get('name', '')} ---")
+
+        if args.experiment:
+            # From profile
+            roots = exp.get("WorkflowRoot", [])
+            if not isinstance(roots, list) or not roots:
+                print(f"Profile must specify 'root' for experiment '{exp_key}'.")
+                sys.exit(1)
+            chosen_root = norm(roots[0])
+            if not exists_path(chosen_root):
+                print(f"Root path does not exist: {chosen_root}")
+                sys.exit(1)
+
+            wfs = exp.get("workflows", [])
+            if not isinstance(wfs, list) or not wfs:
+                print(f"Profile must specify 'workflow' for experiment '{exp_key}'.")
+                sys.exit(1)
+
+            wf = wfs[0]
+            workflow_path = norm(
+                wf if os.path.isabs(wf) else os.path.join(chosen_root, wf.lstrip("\\/"))
+            )
+            workflow_paths = [workflow_path]
+
+        else:
+            # Interactive mode
+            chosen_root = ensure_workflow_root(exp_key, exp, cfg)
+            workflow_paths = ensure_workflows(exp_key, exp, chosen_root, cfg)
+            prompt_parameters_menu(exp_key, exp, chosen_root, cfg)
+
+        base_params = expand_and_validate_parameters(exp_key, exp, chosen_root, cfg)
+        bonsai_cmd_full = resolve_bonsai_cmd(exp_key, exp, chosen_root, cfg)
+
+        # Path check
+        print("\n=== Final Path Check ===")
+        print(
+            "Bonsai exe: ",
+            bonsai_cmd_full,
+            " [OK]" if exists_path(bonsai_cmd_full) else " [MISSING]",
+        )
+        for wf in workflow_paths:
+            print("Workflow:  ", wf, " [OK]" if exists_path(wf) else " [MISSING]")
+        for k, v in base_params.items():
+            if is_probably_path(v) and "://" not in v and not v.startswith("@"):
+                print(f"Param[{k}]:", v, " [OK]" if exists_path(v) else " [MISSING]")
+
+        prepared_per_experiment[exp_key] = {
+            "exp": exp,
+            "root": chosen_root,
+            "workflow": workflow_paths[0],
+            "base_params": base_params,
+            "bonsai": bonsai_cmd_full,
+        }
+
+    # ===============================================
+    # Session-count rules (Option C + your overrides)
+    # ===============================================
+
+    def delphi_profile_session_count(exp_key):
+        cfg_entry = profile.get("experiments_config", {}).get(exp_key, {})
+        sc = cfg_entry.get("session_count")
+        if isinstance(sc, int) and sc >= 1:
+            return sc
+        return 1
+
+    def apply_profile_session_parameters(exp_key: str, session_index: int) -> dict:
+        exp_cfg = profile.get("experiments_config", {}).get(exp_key, {})
+        sess_array = exp_cfg.get("session_parameters", [])
+        if isinstance(sess_array, list) and 0 <= session_index < len(sess_array):
+            entry = sess_array[session_index]
+            return entry if isinstance(entry, dict) else {}
+        return {}
+
+    # ========================================
+    # BUILD SESSIONS
+    # ========================================
+    sessions_to_launch = []
+
+    try:
+        is_delphi_only = (
+            len(selected_keys) == 1 and selected_keys[0].lower() == "delphi"
+        )
+        is_pirouette_only = (
+            len(selected_keys) == 1 and selected_keys[0].lower() == "pirouette"
+        )
+        is_all_experiments = selected_is_all
+
+        # Shared subject/experimenter in all-mode
+        if is_all_experiments:
+            print("\n=== 'All experiments' mode: shared Experimenter/Subject ===")
+            shared_exp = prompt("Experimenter name")
+            shared_sub = prompt("Subject ID")
+
+        last_exp_name = ""
+
+        for exp_key in selected_keys:
+            info = prepared_per_experiment[exp_key]
+            exp = info["exp"]
+            root = info["root"]
+
+            # === Determine session_count ===
+            if args.experiment:
+                if is_delphi_only:
+                    session_count = delphi_profile_session_count(exp_key)
+                elif is_pirouette_only:
+                    session_count = 1
+                elif is_all_experiments:
+                    session_count = 1
+                else:
+                    session_count = 1  # Mixed-profile case
+            else:
+                if exp_key.lower() == "delphi":
+                    session_count = plan_sessions_for_experiment(exp_key)
+                else:
+                    session_count = 1
+
+            # === Build each session ===
+            for i in range(session_count):
+                # Build session
+                if is_all_experiments:
+                    session = build_session_with_values(exp_key, shared_exp, shared_sub)
+                else:
+                    session = build_session(exp_key, experimenter_default=last_exp_name)
+
+                last_exp_name = session["experimenter"] or last_exp_name
+
+                # Save log
+                sf = save_session_record(session)
+                if sf:
+                    print(f"  Session log: {sf}")
+
+                # Start params = base
+                params_abs = dict(info["base_params"])
+
+                # =====================================
+                # PROFILE: per-session parameter override
+                # =====================================
+                if args.experiment and is_delphi_only:
+                    overrides = apply_profile_session_parameters(exp_key, i)
+                    for key, val in overrides.items():
+                        if is_probably_path(val):
+                            abs_val = (
+                                val
+                                if os.path.isabs(val)
+                                else os.path.join(root, val.lstrip("\\/"))
+                            )
+                            val = norm(abs_val)
+                        params_abs[key] = val
+                    if overrides:
+                        print(
+                            f"  Applied per-session profile overrides (session {i + 1}): {overrides}"
+                        )
+
+                # Pirouette temp-file reset
+                if exp_key.lower() == "pirouette":
+                    zero_pirouette_temp_files(root)
+
+                # Per-session schema copies (Delphi)
+                if exp_key.lower() == "delphi":
+                    key = "HardwareSettings"
+                    if key in params_abs and is_probably_path(params_abs[key]):
+                        src = params_abs[key]
+                        params_abs[key] = copy_and_patch_hardware_schema(
+                            src, session["subject_id"], session["start_utc"]
+                        )
+
+                # Per-session schema copies (Pirouette)
+                if exp_key.lower() == "pirouette":
+                    if is_all_experiments:
+                        exp_val = "delphi_pirouette"
+                    else:
+                        exp_val = "pirouette"
+                    key = "SessionPath"
+                    if key in params_abs and is_probably_path(params_abs[key]):
+                        src = params_abs[key]
+                        params_abs[key] = copy_and_patch_aind_session_json(
+                            src,
+                            session["subject_id"],
+                            session["start_utc"],
+                            experimenter=session["experimenter"],
+                            experiment_value=exp_val,
+                        )
+
+                # Named overrides (stored in config)
+                named = build_session_overrides_if_available(exp, session)
+                if named:
+                    params_abs.update(named)
+
+                # Interactive overrides only in interactive mode
+                if not args.experiment:
+                    if prompt_yes_no(
+                        "Override parameters for THIS SESSION?", default_yes=False
+                    ):
+                        params_abs = prompt_per_session_overrides(exp, root, params_abs)
+
+                # Add to launch list
+                sessions_to_launch.append(
+                    {
+                        "exp_key": exp_key,
+                        "bonsai_cmd": info["bonsai"],
+                        "workflow": info["workflow"],
+                        "params": params_abs,
+                        "session": session,
+                    }
+                )
+
+        # === Global launch choice ===
+        if auto_start_from_profile is None:
+            auto_start = prompt_launch_mode()
+        else:
+            auto_start = bool(auto_start_from_profile)
+            print(f"\nAuto-start (from profile): {auto_start}")
+
+        if parallel_from_profile is None:
+            parallel = prompt_run_mode()
+        else:
+            parallel = bool(parallel_from_profile)
+            print(f"Parallel (from profile): {parallel}")
+
+        # === Summary & confirm ===
+        print_prelaunch_summary(sessions_to_launch, auto_start, parallel)
+        if not prompt_yes_no("Proceed to launch?", default_yes=True):
+            print("Cancelled.")
+            sys.exit(0)
+
+        # === Launch Bonsai FIRST ===
+        WORKFLOW_PROCS.clear()
+        if parallel:
+            for s in sessions_to_launch:
+                p = launch_bonsai(
+                    s["bonsai_cmd"], s["workflow"], s["params"], auto_start
+                )
+                WORKFLOW_PROCS.append(p)
+        else:
+            for s in sessions_to_launch:
+                p = launch_bonsai(
+                    s["bonsai_cmd"], s["workflow"], s["params"], auto_start
+                )
+                WORKFLOW_PROCS.append(p)
+
+        # === Lifealert control menu ===
+        pir_selected = any(
+            s["exp_key"].lower() == "pirouette" for s in sessions_to_launch
+        )
+
+        while True:
+            print("\n=== Control Menu ===")
+            print("  1. Start lifealert")
+            print("  2. Stop lifealert")
+            print("  3. Show status")
+            print("  4. Wait for workflows")
+            print("  5. Exit & cleanup")
+            if not pir_selected:
+                print("  (Pirouette not selected — lifealert disabled)")
+
+            sel = input("Select: ").strip()
+            if sel == "1":
+                if pir_selected:
+                    start_lifealert_with_menu(cfg, prepared_per_experiment)
+                else:
+                    print("Pirouette not selected.")
+            elif sel == "2":
+                stop_lifealert()
+            elif sel == "3":
+                show_status()
+            elif sel == "4":
+                wait_for_workflows()
+            elif sel == "5":
+                break
+            else:
+                print("Invalid selection.")
+
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+    finally:
+        cleanup_temp_files_and_processes()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -825,7 +825,12 @@ def copy_and_patch_aind_session_json(
             obj = {}
 
     obj["subject"] = subject_id
-    obj["date"] = start_utc_hyphen  # hyphen UTC
+
+    # Convert session start (hyphen format) to true RFC3339/ISO-8601 timestamp
+    # Example target: 2026-03-13T16:11:58.419072Z
+    dt = datetime.strptime(start_utc_hyphen, "%Y-%m-%dT%H-%M-%S")
+    dt = dt.replace(tzinfo=timezone.utc)
+    obj["date"] = dt.isoformat(timespec="microseconds").replace("+00:00", "Z")
     obj["session_name"] = f"{subject_id}_{start_utc_hyphen}"
     obj["experimenter"] = [experimenter] if experimenter else []
     obj["experiment"] = experiment_value

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -31,9 +31,12 @@ import os
 import re
 import sys
 import subprocess
+import time
 from pathlib import Path
 from typing import Dict, Any, List, Tuple, Optional
 from datetime import datetime, timezone
+
+import psutil
 
 # Optional YAML support (if PyYAML is available)
 try:
@@ -1023,15 +1026,9 @@ def stop_lifealert():
 
     print("Stopping lifealert processes...")
 
-    for p in LIFEALERT_PROCS:
+    for p in LIFEALERT_PROCS[:]:
         try:
-            # Step 1: Try normal force terminate
-            p.kill()
-        except Exception:
-            pass
-
-        try:
-            # Step 2: Force kill including all children (Windows)
+            # Kill process tree decisively
             subprocess.run(
                 ["taskkill", "/PID", str(p.pid), "/F", "/T"],
                 stdout=subprocess.DEVNULL,
@@ -1041,8 +1038,20 @@ def stop_lifealert():
         except Exception:
             pass
 
+    # CRITICAL: wait for Windows to release file handles
+    gone, alive = psutil.wait_procs(LIFEALERT_PROCS, timeout=10)
+
+    if alive:
+        raise RuntimeError(
+            f"Lifealert did not fully exit. Still alive: {[p.pid for p in alive]}"
+        )
+
     LIFEALERT_PROCS.clear()
-    print("lifealert stopped.")
+
+    # Extra grace period for Windows handle cleanup
+    time.sleep(1.5)
+
+    print("lifealert stopped cleanly.")
 
 
 def start_lifealert_with_menu(
@@ -1119,10 +1128,7 @@ def cleanup_temp_files_and_processes():
         print("Stopping lifealert processes...")
         for p in LIFEALERT_PROCS:
             try:
-                p.kill()
-            except Exception:
-                pass
-            try:
+                # Kill process tree decisively
                 subprocess.run(
                     ["taskkill", "/PID", str(p.pid), "/F", "/T"],
                     stdout=subprocess.DEVNULL,

--- a/src/launcher/launcher.py
+++ b/src/launcher/launcher.py
@@ -1020,12 +1020,27 @@ def stop_lifealert():
     if not LIFEALERT_PROCS:
         print("No lifealert process is currently running.")
         return
+
     print("Stopping lifealert processes...")
+
     for p in LIFEALERT_PROCS:
         try:
+            # Step 1: Try normal terminate
             p.terminate()
         except Exception:
             pass
+
+        try:
+            # Step 2: Force kill including all children (Windows)
+            subprocess.run(
+                ["taskkill", "/PID", str(p.pid), "/F", "/T"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVICE,
+                creationflags=subprocess.CREATE_NO_WINDOW
+            )
+        except Exception:
+            pass
+
     LIFEALERT_PROCS.clear()
     print("lifealert stopped.")
 
@@ -1097,22 +1112,45 @@ def wait_for_workflows():
 
 
 def cleanup_temp_files_and_processes():
-    if TEMP_SESSION_FILES:
-        print("\nCleaning up per-session override and temp files:")
-        for fp in TEMP_SESSION_FILES:
-            try:
-                Path(fp).unlink(missing_ok=True)
-                print(f"  removed: {fp}")
-            except Exception as e:
-                print(f"  warning: could not remove {fp}: {e}")
+    print("\nRunning cleanup routine...")
+
+    # --- Kill lifealert first (if running), same logic as stop_lifealert() ---
     if LIFEALERT_PROCS:
-        print("\nStopping lifealert processes...")
+        print("Stopping lifealert processes...")
         for p in LIFEALERT_PROCS:
             try:
                 p.terminate()
             except Exception:
                 pass
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(p.pid), "/F", "/T"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    creationflags=subprocess.CREATE_NO_WINDOW
+                )
+            except Exception:
+                pass
         LIFEALERT_PROCS.clear()
+
+    # --- NOW remove temp files ---
+    if TEMP_SESSION_FILES:
+        print("Cleaning up per-session override and temp files:")
+        for fp in TEMP_SESSION_FILES:
+            try:
+                Path(fp).unlink(missing_ok=True)
+                print(f"  removed: {fp}")
+            except PermissionError:
+                # Windows file lock — retry after short sleep
+                import time
+                time.sleep(0.2)
+                try:
+                    Path(fp).unlink(missing_ok=True)
+                    print(f"  removed after retry: {fp}")
+                except Exception as e:
+                    print(f"  ERROR: could not remove {fp}: {e}")
+            except Exception as e:
+                print(f"  WARNING: could not remove {fp}: {e}")
 
 
 # -------------------------------
@@ -1568,32 +1606,44 @@ def main():
             s["exp_key"].lower() == "pirouette" for s in sessions_to_launch
         )
 
+        # === CONTROL MENU ===
         while True:
-            print("\n=== Control Menu ===")
-            print("  1. Start lifealert")
-            print("  2. Stop lifealert")
-            print("  3. Show status")
-            print("  4. Wait for workflows")
-            print("  5. Exit & cleanup")
-            if not pir_selected:
-                print("  (Pirouette not selected — lifealert disabled)")
+            try:
+                print("\n=== Control Menu ===")
+                print("  1. Start lifealert")
+                print("  2. Stop lifealert")
+                print("  3. Show status")
+                print("  4. Wait for workflows")
+                print("  5. Exit & cleanup")
+                if not pir_selected:
+                    print("  (Pirouette not selected — lifealert disabled)")
 
-            sel = input("Select: ").strip()
-            if sel == "1":
-                if pir_selected:
-                    start_lifealert_with_menu(cfg, prepared_per_experiment)
+                sel = input("Select: ").strip()
+
+                if sel == "1":
+                    if pir_selected:
+                        start_lifealert_with_menu(cfg, prepared_per_experiment)
+                    else:
+                        print("Pirouette not selected.")
+
+                elif sel == "2":
+                    stop_lifealert()  # Updated function will hard-kill uv + children
+
+                elif sel == "3":
+                    show_status()
+
+                elif sel == "4":
+                    wait_for_workflows()
+
+                elif sel == "5":
+                    break
+
                 else:
-                    print("Pirouette not selected.")
-            elif sel == "2":
-                stop_lifealert()
-            elif sel == "3":
-                show_status()
-            elif sel == "4":
-                wait_for_workflows()
-            elif sel == "5":
+                    print("Invalid selection.")
+
+            except KeyboardInterrupt:
+                print("\nCtrl+C detected — exiting control menu and cleaning up...")
                 break
-            else:
-                print("Invalid selection.")
 
     except KeyboardInterrupt:
         print("\nInterrupted.")

--- a/src/launcher/launcher_config.json
+++ b/src/launcher/launcher_config.json
@@ -1,0 +1,44 @@
+{
+  "EXPERIMENTS": {
+    "Delphi": {
+      "name": "Delphi",
+      "WorkflowRoot": [
+        "C:/Users/brandon.pratt/Desktop/code/Delphi"
+      ],
+      "workflows": [
+        "src/DelphiMain.bonsai"
+      ],
+      "parameters": {
+        "HardwareSettings": "src/schemas/hardware-schema.yml",
+        "RuleSettings": "src/schemas/rule-3.yml",
+        "NextRuleSettings": "src/schemas/rule-5.yml"
+      },
+      "BONSAI_CMD": "/.bonsai/Bonsai.exe",
+      "ParameterOptions": {
+        "HardwareSettings": [
+          "src/schemas/hardware-schema3.yml",
+          "src/schemas/hardware-schema.yml"
+        ]
+      }
+    },
+    "Pirouette": {
+      "name": "Pirouette",
+      "WorkflowRoot": [
+        "C:/Users/brandon.pratt/Desktop/code/Aind.Behavior.Pirouette"
+      ],
+      "workflows": [
+        "src/WrappedPirouette.bonsai"
+      ],
+      "parameters": {
+        "RigPath": "local/AindBehaviorPirouetteRig.json",
+        "SessionPath": "local/AindBehaviorSessionModel.json",
+        "ConnectionString": "@tcp://localhost:5557",
+        "LifealertRoot": "C:/Users/brandon.pratt/Desktop/code/lifealert"
+      },
+      "BONSAI_CMD": "/bonsai/Bonsai.exe",
+      "LifealertOptions": [
+        "C:/Users/brandon.pratt/Desktop/code/lifealert"
+      ]
+    }
+  }
+}

--- a/src/launcher/launcher_config.json
+++ b/src/launcher/launcher_config.json
@@ -3,7 +3,7 @@
     "Delphi": {
       "name": "Delphi",
       "WorkflowRoot": [
-        "C:/Users/svc_aind_chronic/Documents/code/Delphi"
+        "C:\\Users\\brandon.pratt\\Desktop\\code\\Delphi"
       ],
       "workflows": [
         "src/DelphiMain.bonsai"
@@ -13,7 +13,7 @@
         "RuleSettings": "src/schemas/rule-3.yml",
         "NextRuleSettings": "src/schemas/rule-3.yml"
       },
-      "BONSAI_CMD": "C:/Users/svc_aind_chronic/Documents/code/Delphi/.bonsai/Bonsai.exe",
+      "BONSAI_CMD": ".bonsai/Bonsai.exe",
       "ParameterOptions": {
         "HardwareSettings": [
           "src/schemas/hardware-schema3.yml",
@@ -24,7 +24,7 @@
     "Pirouette": {
       "name": "Pirouette",
       "WorkflowRoot": [
-        "C:/Users/svc_aind_chronic/Documents/code/Aind.Behavior.Pirouette"
+        "C:\\Users\\brandon.pratt\\Desktop\\code\\Aind.Behavior.Pirouette"
       ],
       "workflows": [
         "src/WrappedPirouette.bonsai"
@@ -33,11 +33,12 @@
         "RigPath": "local/AindBehaviorPirouetteRig.json",
         "SessionPath": "local/AindBehaviorSessionModel.json",
         "ConnectionString": "@tcp://localhost:5557",
-        "LifealertRoot": "C:/Users/svc_aind_chronic/Documents/code/lifealert"
+        "LifealertRoot": "C:/Users/brandon.pratt/Desktop/code/lifealert"
       },
-      "BONSAI_CMD": "C:/Users/svc_aind_chronic/Documents/code/Aind.Behavior.Pirouette/bonsai/Bonsai.exe",
+      "BONSAI_CMD": "bonsai/Bonsai.exe",
       "LifealertOptions": [
-        "C:/Users/svc_aind_chronic/Documents/code/lifealert"
+        "C:/Users/svc_aind_chronic/Documents/code/lifealert",
+        "C:/Users/brandon.pratt/Desktop/code/lifealert"
       ]
     }
   }

--- a/src/launcher/launcher_config.json
+++ b/src/launcher/launcher_config.json
@@ -3,7 +3,7 @@
     "Delphi": {
       "name": "Delphi",
       "WorkflowRoot": [
-        "C:/Users/brandon.pratt/Desktop/code/Delphi"
+        "C:/Users/svc_aind_chronic/Documents/code/Delphi"
       ],
       "workflows": [
         "src/DelphiMain.bonsai"
@@ -11,9 +11,9 @@
       "parameters": {
         "HardwareSettings": "src/schemas/hardware-schema.yml",
         "RuleSettings": "src/schemas/rule-3.yml",
-        "NextRuleSettings": "src/schemas/rule-5.yml"
+        "NextRuleSettings": "src/schemas/rule-3.yml"
       },
-      "BONSAI_CMD": "/.bonsai/Bonsai.exe",
+      "BONSAI_CMD": "C:/Users/svc_aind_chronic/Documents/code/Delphi/.bonsai/Bonsai.exe",
       "ParameterOptions": {
         "HardwareSettings": [
           "src/schemas/hardware-schema3.yml",
@@ -24,7 +24,7 @@
     "Pirouette": {
       "name": "Pirouette",
       "WorkflowRoot": [
-        "C:/Users/brandon.pratt/Desktop/code/Aind.Behavior.Pirouette"
+        "C:/Users/svc_aind_chronic/Documents/code/Aind.Behavior.Pirouette"
       ],
       "workflows": [
         "src/WrappedPirouette.bonsai"
@@ -33,11 +33,11 @@
         "RigPath": "local/AindBehaviorPirouetteRig.json",
         "SessionPath": "local/AindBehaviorSessionModel.json",
         "ConnectionString": "@tcp://localhost:5557",
-        "LifealertRoot": "C:/Users/brandon.pratt/Desktop/code/lifealert"
+        "LifealertRoot": "C:/Users/svc_aind_chronic/Documents/code/lifealert"
       },
-      "BONSAI_CMD": "/bonsai/Bonsai.exe",
+      "BONSAI_CMD": "C:/Users/svc_aind_chronic/Documents/code/Aind.Behavior.Pirouette/bonsai/Bonsai.exe",
       "LifealertOptions": [
-        "C:/Users/brandon.pratt/Desktop/code/lifealert"
+        "C:/Users/svc_aind_chronic/Documents/code/lifealert"
       ]
     }
   }

--- a/src/schemas/hardware-schema.json
+++ b/src/schemas/hardware-schema.json
@@ -110,6 +110,14 @@
     }
   },
   "properties": {
+    "subject_id": {
+      "title": "Subject Id",
+      "type": "string"
+    },
+    "session_time": {
+      "title": "Session Time",
+      "type": "string"
+    },
     "logging_root_path": {
       "title": "Logging Root Path",
       "type": "string"
@@ -126,6 +134,8 @@
     }
   },
   "required": [
+    "subject_id",
+    "session_time",
     "logging_root_path",
     "remote_transfer_root_path",
     "delphi_controller",

--- a/src/schemas/hardware-schema.json
+++ b/src/schemas/hardware-schema.json
@@ -126,6 +126,10 @@
       "title": "Remote Transfer Root Path",
       "type": "string"
     },
+    "robocopy_script_path": {
+      "title": "Robocopy Script Path",
+      "type": "string"
+    },
     "delphi_controller": {
       "$ref": "#/$defs/DelphiController"
     },
@@ -138,6 +142,7 @@
     "session_time",
     "logging_root_path",
     "remote_transfer_root_path",
+    "robocopy_script_path",
     "delphi_controller",
     "camera_settings"
   ],

--- a/src/schemas/hardware-schema.yml
+++ b/src/schemas/hardware-schema.yml
@@ -1,11 +1,12 @@
 # yaml-language-server: $schema=hardware-schema.json
 subject_id: '801055'
 session_time: '2024-06-01T12:00:00Z'
-logging_root_path: C:\Users\svc_aind_chronic\Documents\data
-remote_transfer_root_path: \\allen\aind\stage\chronic\Delphi
+logging_root_path: D:/data
+robocopy_script_path: C:/Users/svc_aind_chronic/Documents/code/Delphi/src/python/robocopy.py
+remote_transfer_root_path: //allen/aind/stage/chronic/data
 
 delphi_controller:
-  final_valve_energized_time_us: 110000
+  final_valve_energized_time_us: 0
   max_odor_delivery_time_us: 10000000
   min_poke_time_us: 10000
   min_odor_delivery_time_us: 10000
@@ -13,13 +14,13 @@ delphi_controller:
   poke_pin: 22
   vacuum_setup_time_us: 10000
   vacuum_close_time_us: 20000
-  com_port: COM3
+  com_port: COM7
 
 camera_settings:
   camera_name: PortCamera
   frame_rate: 100
   exposure: 5000
   duty_cycle: 0.5
-  serial_number: '23373886'
+  serial_number: '23354675'
   ffmpeg_input: -colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear
-  ffmpeg_output: -vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v h264_qsv -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune film -preset fast -crf 21 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M
+  ffmpeg_output: -vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v libx264 -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune film -preset fast -crf 21 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M

--- a/src/schemas/hardware-schema.yml
+++ b/src/schemas/hardware-schema.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=hardware-schema.json
-
+subject_id: '801055'
+session_time: '2024-06-01T12:00:00Z'
 logging_root_path: C:\Users\svc_aind_chronic\Documents\data
 remote_transfer_root_path: \\allen\aind\stage\chronic\Delphi
 

--- a/src/schemas/rule-3.yml
+++ b/src/schemas/rule-3.yml
@@ -2,7 +2,7 @@
 
 rule:
   rule_alias: Standard
-  init_odor_index: 5
+  init_odor_index: 0x0010
   sample_with_replacement: true
   state_definitions: [
     {name: DefaultState, odor_index: 0x0010, transitions_to: [OdorA]},

--- a/src/schemas/schema.py
+++ b/src/schemas/schema.py
@@ -28,6 +28,8 @@ class CameraSettings(BaseModel):
 
 
 class HardwareSchema(BaseModel):
+    subject_id: str
+    session_time: str
     logging_root_path: str
     remote_transfer_root_path: str
     delphi_controller: DelphiController

--- a/src/schemas/schema.py
+++ b/src/schemas/schema.py
@@ -32,6 +32,7 @@ class HardwareSchema(BaseModel):
     session_time: str
     logging_root_path: str
     remote_transfer_root_path: str
+    robocopy_script_path: str
     delphi_controller: DelphiController
     camera_settings: CameraSettings
 


### PR DESCRIPTION
The goal here was to refactor the launching of experiments and structuring of session data. The following was implemented:
- Session data structure: Subject id/session date/runs.
- A CLI-based experimenter launcher that maps session metadata into updated schema files and has two modes, an interactive mode that allows a user to define each aspect of the session (e.g. number of delphi workflows to launch), and a profile mode where session parameters are predefined in a .json config and passed to the launcher through the experiment argument. 

I tested these upgrades and they worked as expected. @RoboDoig, can you review these changes and approve them if everything checks out on your end? 